### PR TITLE
#20 java outofmemory exception when creating Glance image.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<url>http://github.com/gondor/openstack4j/</url>
 	</scm>
 	<dependencies>
+	
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
@@ -77,6 +78,11 @@
 					<artifactId>junit</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.connectors</groupId>
+			<artifactId>jersey-apache-connector</artifactId>
+			<version>2.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/openstack4j/core/transport/internal/ClientFactory.java
+++ b/src/main/java/org/openstack4j/core/transport/internal/ClientFactory.java
@@ -21,6 +21,9 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import org.glassfish.jersey.apache.connector.ApacheConnector;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.spi.Connector;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.openstack4j.core.transport.ClientConstants;
 
@@ -47,11 +50,13 @@ class ClientFactory {
 			return getNonStrictSSLClient();
 		
 		if (clientStrict == null) {
-			clientStrict = ClientBuilder.newBuilder()
-					 									.register(JacksonFeature.class)
-					 									.register(RESOLVER)
-					 									.register(new RequestFilter())
-					 									.build();
+			ClientConfig clientConfig = new ClientConfig();
+			clientConfig.register(JacksonFeature.class);
+			clientConfig.register(RESOLVER);
+			clientConfig.register(new RequestFilter());
+			Connector connector = new ApacheConnector(clientConfig.getConfiguration());
+			clientConfig.connector(connector);
+			clientStrict = ClientBuilder.newClient(clientConfig);
 		}
 		
 		return clientStrict;


### PR DESCRIPTION
this issue is jersey lib problem. reference below url
I changed http client to ApacheConnector in ClientFactory.java and add
dependency of jersey-apache-connector in pom 

https://java.net/jira/browse/JERSEY-2024
http://jersey.576304.n2.nabble.com/Jersey2-Client-OutOfMemoryError-when-uploading-large-file-td7581068.html

I solved and tested. 
I changed Connector to ApacheConnector in ClientFactory class and added ApacheConnector lib dependency in pom.xml

thank you.
