### PR TITLE
Keep header 'Accept' values 'application/json'

### DIFF
--- a/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
+++ b/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
@@ -10,6 +10,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 import org.openstack4j.api.exceptions.ConnectionException;
 import org.openstack4j.api.exceptions.ResponseException;
@@ -77,7 +78,7 @@ public class HttpExecutor implements HttpExecutorService {
 		
 		target = populateQueryParams(target, request);
 
-		Invocation.Builder invocation = target.request();
+		Invocation.Builder invocation = target.request(MediaType.APPLICATION_JSON);
 		populateHeaders(invocation,  request);
 
 		Entity<?> entity = (request.getEntity() == null) ? null :


### PR DESCRIPTION
I debug the code for solving my issue ＃24（https://github.com/gondor/openstack4j/issues/24） 
I found that when I call `List<? extends Meter> meters= meterService.list();`,the code in method invoke() here entity is null, and  the code runs the lase return `return HttpResponse.wrap(invocation.method(request.getMethod().name()));`
so I add the invocation's Accpet Type by add `MediaType.APPLICATION_JSON`to the target.request() method to make sure the request header 'Accept' always values 'application/json'
