### PR TITLE
Enabled userdata on server creation

### DIFF
--- a/src/main/java/org/openstack4j/model/compute/builder/ServerCreateBuilder.java
+++ b/src/main/java/org/openstack4j/model/compute/builder/ServerCreateBuilder.java
@@ -77,6 +77,14 @@ public interface ServerCreateBuilder extends Buildable.Builder<ServerCreateBuild
 	 * @param availabilityZone the availability zone
 	 * @return this builder
 	 */
-	ServerCreateBuilder availabilityZone(String availabilityZone); 
+	ServerCreateBuilder availabilityZone(String availabilityZone);
+
+    /**
+     * Cloud-init userdata
+     *
+     * @param userData a base64 encoded string containing the userdata
+     * @return this userdata
+     */
+    ServerCreateBuilder userData(String userData);
 	
 }

--- a/src/main/java/org/openstack4j/openstack/compute/domain/NovaServerCreate.java
+++ b/src/main/java/org/openstack4j/openstack/compute/domain/NovaServerCreate.java
@@ -256,5 +256,11 @@ public class NovaServerCreate implements ServerCreate {
 			m = (NovaServerCreate)in;
 			return this;
 		}
+
+        @Override
+        public ServerCreateBuilder userData(String userData) {
+            m.userData = userData;
+            return this;
+        }
 	}
 }


### PR DESCRIPTION
Enables you to sent a base64 encoded string containing configuration information ( userdata )at creation of a server. See issue #56 ( https://github.com/gondor/openstack4j/issues/56 )
