### PR TITLE
Capture CPU Info/Topology as part of hypervisor detail

### DIFF
--- a/core/src/main/java/org/openstack4j/model/compute/ext/Hypervisor.java
+++ b/core/src/main/java/org/openstack4j/model/compute/ext/Hypervisor.java
@@ -1,5 +1,7 @@
 package org.openstack4j.model.compute.ext;
 
+import java.util.List;
+
 import org.openstack4j.model.ModelEntity;
 
 /**
@@ -128,6 +130,14 @@ public interface Hypervisor extends ModelEntity {
 	
 	
 	/**
+	 * Gets the cpu info.
+	 * 
+	 * @return CPUInfo
+	 */
+	CPUInfo getCPUInfo();
+	
+	
+	/**
 	 * The Hypervisor Services Detail
 	 * 
 	 * @author Jeremy Unruh
@@ -147,6 +157,54 @@ public interface Hypervisor extends ModelEntity {
 		 * @return the id
 		 */
 		String getId();
+	}
+	
+	public interface CPUInfo extends ModelEntity {
+	  
+	  /**
+	   * @return cpu vendor
+	   */
+	  String getVendor();
+	  
+	  /**
+	   * @return cpu model
+	   */
+	  String getModel();
+	  
+	  /**
+	   * @return chipset architecture
+	   */
+	  String getArch();
+	  
+	  /**
+	   * @return cpu feature set
+	   */
+	  List<String> getFeatures();
+	  
+	  
+	  /**
+	   * @return cpu topology
+	   */
+	  CPUTopology getTopology();
+	}
+	
+	public interface CPUTopology extends ModelEntity {
+	  
+	  /**
+	   * @return core count
+	   */
+	  int getCores();
+	  
+	  
+	  /**
+	   * @return thread count
+	   */
+	  int getThreads();
+	  
+	  /**
+	   * @return socket count
+	   */
+	  int getSockets();
 	}
 	
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 			<artifactId>jsr305</artifactId>
 			<version>2.0.0</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.2.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Added CPU Info and CPUTopology as sub-objects of Hypervisor, similar to the embedded Service object.

Ran into problem (we're running Icehouse) where OpenStack API is returning String literal "{...}" for cpu_info instead of object notation {...} so had to hack using gson to parse that portion of json string into proper CPUInfo object.

Added gson as dependency to parent pom :(
