### PR TITLE
fix attach volume bug with resteasy

### DIFF
--- a/core/src/main/java/org/openstack4j/api/compute/ServerService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ServerService.java
@@ -212,7 +212,7 @@ public interface ServerService {
      * @author octopus zhang
      * @return volumeAttachment or null if not applicable
      */
-    VolumeAttachment attachVolume(String serverId, String volumeId);
+    void attachVolume(String serverId, String volumeId);
     
     /**
      * Changes the admin/root password on the server

--- a/core/src/main/java/org/openstack4j/model/compute/VolumeAttachment.java
+++ b/core/src/main/java/org/openstack4j/model/compute/VolumeAttachment.java
@@ -10,24 +10,6 @@ import org.openstack4j.model.ModelEntity;
 public interface VolumeAttachment extends ModelEntity {
 	
 	/**
-	 * the device name in the server,like /dev/vdd
-	 * @return device name
-	 */
-	String getDevice();
-	
-    /**
-	 * Gets the id.
-	 * @return the id
-	 */
-	String getId();
-	
-	/**
-	 * the server's id int this attachment
-	 * @return the id
-	 */
-	String getServerId();
-	
-	/**
 	 * the volume's id int this attachment
 	 * @return the id
 	 */

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaVolumeAttachment.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaVolumeAttachment.java
@@ -16,32 +16,7 @@ public class NovaVolumeAttachment implements VolumeAttachment {
 
 	private static final long serialVersionUID = 1L;
 
-	@JsonProperty
-	private String device;
-
-	@JsonProperty
-	private String id;
-
-	@JsonProperty
-	private String serverId;
-
-	@JsonProperty
 	private String volumeId;
-
-	@Override
-	public String getDevice() {
-		return device;
-	}
-
-	@Override
-	public String getId() {
-		return id;
-	}
-
-	@Override
-	public String getServerId() {
-		return serverId;
-	}
 
 	@Override
 	public String getVolumeId() {
@@ -51,9 +26,12 @@ public class NovaVolumeAttachment implements VolumeAttachment {
 	@Override
 	public String toString() {
 		return Objects.toStringHelper(this).omitNullValues()
-				.add("device", device).add("id", id).add("serverId", serverId)
 				.add("volumeId", volumeId).toString();
 
+	}
+	
+	public NovaVolumeAttachment(String volumeId) {
+		this.volumeId = volumeId;
 	}
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
@@ -305,9 +305,9 @@ public class ServerServiceImpl extends BaseComputeServices implements ServerServ
      * {@inheritDoc}
      */
     @Override
-    public VolumeAttachment attachVolume(String serverId, String volumeId) {
-        String body = String.format("{\"volumeAttachment\":{ \"volumeId\": \"%s\" }}", volumeId);
-        return post(NovaVolumeAttachment.class, uri("/servers/%s/os-volume_attachments", serverId)).json(body).execute();
+    public void attachVolume(String serverId, String volumeId) {
+        NovaVolumeAttachment volumeAttachment = new NovaVolumeAttachment(volumeId);
+        post(Void.class, uri("/servers/%s/os-volume_attachments", serverId)).entity(volumeAttachment).execute();
     }
 
     /**


### PR DESCRIPTION
Fixed #111 :Attach volume now return a volumeAttachment, but it does not really make sense.We don't know whether this attach opreation will successd from the  volumeAttachment. And there is already CinderVolumeAttachment class which have same  structure existing. So I remove device ,id ,server from it,and change it a entity for attaching volume and solve attachving volume's bug with resteasy
