### PR TITLE
fix wrong text encoding bug when using non-iso character.

### DIFF
--- a/connectors/httpclient/src/main/java/org/openstack4j/connectors/httpclient/HttpCommand.java
+++ b/connectors/httpclient/src/main/java/org/openstack4j/connectors/httpclient/HttpCommand.java
@@ -122,16 +122,18 @@ public final class HttpCommand<R> {
         EntityBuilder builder = null;
 
         if (request.getEntity() != null) {
-            builder = EntityBuilder.create()
-                    .setContentType(ContentType.create(request.getContentType()));
+            builder = EntityBuilder.create();
             
             if (InputStream.class.isAssignableFrom(request.getEntity().getClass())) 
             {
-                builder.setBinary(ByteStreams.toByteArray((InputStream)request.getEntity()));
+                builder
+                	.setContentType(ContentType.create(request.getContentType()))
+                	.setBinary(ByteStreams.toByteArray((InputStream)request.getEntity()));
             }
             else
             {
                 builder
+                	.setContentType(ContentType.create(request.getContentType(),"UTF-8"))
                     .setText(ObjectMapperSingleton.getContext(request.getEntity().getClass()).writer().writeValueAsString(request.getEntity()))
                     .setContentEncoding("UTF-8");
             }


### PR DESCRIPTION
When using httpclient connector, if I set entity's label to Chinese, will get '?' when getting the value back. this pull fix this issue.
