### PR TITLE
Fix NPE when calling os.identity().tenants().list() on Identity v2

### DIFF
--- a/src/main/java/org/openstack4j/openstack/identity/domain/KeystoneAccess.java
+++ b/src/main/java/org/openstack4j/openstack/identity/domain/KeystoneAccess.java
@@ -1,5 +1,6 @@
 package org.openstack4j.openstack.identity.domain;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
@@ -25,7 +26,7 @@ public class KeystoneAccess implements Access {
 	private static final long serialVersionUID = 1L;
 	private static final String CACHE_FMT = "%s:%s";
 	private KeystoneToken token;
-	private List<AccessService> serviceCatalog;
+	private List<AccessService> serviceCatalog = new ArrayList<AccessService>();
 	private AccessUser user;
 	private String endpoint;
 	private AuthStore credentials;


### PR DESCRIPTION
I'm not sure this is the right thing to do, but I don't see any reference to service catalogs in the V2 API. Another take on this fix would be at https://github.com/gondor/openstack4j/blob/1.0.3/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java#L64. Usually I prefer empty collections to checking for null.

Am I missing something or is this really a bug ?

Stack trace:

``` java
java.lang.NullPointerException
    at org.openstack4j.openstack.identity.internal.DefaultEndpointURLResolver.resolveV2(DefaultEndpointURLResolver.java:64)
    at org.openstack4j.openstack.identity.internal.DefaultEndpointURLResolver.findURL(DefaultEndpointURLResolver.java:49)
    at org.openstack4j.openstack.internal.OSClientSession.getEndpoint(OSClientSession.java:179)
    at org.openstack4j.core.transport.HttpRequest$RequestBuilder.build(HttpRequest.java:373)
    at org.openstack4j.openstack.internal.BaseOpenStackService$Invocation.execute(BaseOpenStackService.java:135)
    at org.openstack4j.openstack.internal.BaseOpenStackService$Invocation.execute(BaseOpenStackService.java:131)
    at org.openstack4j.openstack.identity.internal.TenantServiceImpl.list(TenantServiceImpl.java:21)
```
