### PR TITLE
Fix #635: Do not propagate null response header from http-connector

### DIFF
--- a/connectors/http-connector/src/main/java/org/openstack4j/connectors/http/HttpResponseImpl.java
+++ b/connectors/http-connector/src/main/java/org/openstack4j/connectors/http/HttpResponseImpl.java
@@ -126,6 +126,7 @@ public class HttpResponseImpl implements HttpResponse {
         Set<String> keys = headers.keySet();
 
         for (String key : keys) {
+            if (key == null) continue; // Ignore null header where HttpURLConnection stores HTTP method info
             List<String> values = headers.get(key);
             for (String value : values) {
                 retHeaders.put(key, value);


### PR DESCRIPTION
Fixes https://github.com/gondor/openstack4j/issues/635.

It seems that similar fix was already done in `HttpResponseImpl#header(String)` in unrelated change.