### PR TITLE
Add managing OS::Heat::None

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/heat/utils/Environment.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/utils/Environment.java
@@ -50,9 +50,12 @@ public class Environment {
         if (rr == null ) return;
         if(rr.get("base_url") != null ) setBaseUrl(new URL(rr.get("base_url")));
         for(String resourceType: rr.keySet()) {
-            if(resourceType.equals("base_url"))
+        	if(resourceType.equals("base_url"))
                 continue;
-
+            
+            if("OS::Heat::None".equals(rr.get(resourceType)))
+            		continue;
+            
             URL tplUrl = new URL(baseUrl, rr.get(resourceType));
 
             Template tpl = new Template(tplUrl);


### PR DESCRIPTION
Hi,

Since Liberty, in the resource_registry we can use OS::Heat::None for disable or enables easily certain resources (http://docs.openstack.org/developer/heat/template_guide/openstack.html#OS::Heat::None).
I change the code, when this special entry is present, it doesn't try to load a content file and continue.
I made some tests in my use case and it seems to be good.

Bests regards.

Frédéric.