### PR TITLE
best reading nested template

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/heat/utils/Template.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/utils/Template.java
@@ -75,7 +75,7 @@ public class Template {
                 if(isTemplate(skey, valueInString)) {
                     try {
                         final String templateName = valueInString;
-                    	final URL fullTemplateName =  TemplateUtils.normaliseFilePathToUrl(baseUrl + templateName);
+                    	final URL fullTemplateName =  TemplateUtils.normaliseFilePathToUrl(baseUrl.toString(), templateName);
 
                         if(! files.containsKey(templateName)) {
                             final Template tpl = new Template(fullTemplateName);

--- a/core/src/main/java/org/openstack4j/openstack/heat/utils/TemplateUtils.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/utils/TemplateUtils.java
@@ -41,4 +41,15 @@ public class TemplateUtils {
         }
         
     }
+
+    public static URL normaliseFilePathToUrl(String baseUrl, String templateName)
+            throws MalformedURLException, URISyntaxException {
+        if (templateName.startsWith("file:")
+                || templateName.startsWith("http:")
+                || templateName.startsWith("https:")) {
+            return normaliseFilePathToUrl(templateName);
+        } else {
+            return normaliseFilePathToUrl(baseUrl + templateName);
+        }
+    }
 }


### PR DESCRIPTION
Hi,

If you use nested template and you have a mixed in the type property of a resource of relative path, absolute path, Http URL, Https URL, the loading of the nested templates failed because the path isn't correct.
I push a new method to calculate when the baseurl is needed or not to get the correct path to the file.

Cheers,

Frédéric
