### PR TITLE
Fix #673: Bring back Java 7 support

### DIFF
--- a/connectors/http-connector/pom.xml
+++ b/connectors/http-connector/pom.xml
@@ -9,7 +9,7 @@
     <name>OpenStack4j HttpURL Connector</name>
     <artifactId>openstack4j-http-connector</artifactId>
     <packaging>jar</packaging>
-    
+
  	<build>
 		<plugins>
 			<plugin>
@@ -27,10 +27,10 @@
 							!org.openstack4j.connectors.http
 							*
 						</Import-Package>
-						<!-- 
+						<!--
 						Required for SPI in OSGi:
 						http://aries.apache.org/modules/spi-fly.html#specconf
-						
+
 						This bundle defines an implementation for following services in META-INF-services:
 						org.openstack4j.core.transport.HttpExecutorService
 						 -->
@@ -41,6 +41,18 @@
 							osgi.serviceloader; osgi.serviceloader=org.openstack4j.core.transport.HttpExecutorService
 						</Provide-Capability>
 					</instructions>
+				</configuration>
+			</plugin>
+
+			<!-- JDK 1.8 required by this connector (https://github.com/ContainX/openstack4j/issues/673) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/connectors/jersey2/pom.xml
+++ b/connectors/jersey2/pom.xml
@@ -31,7 +31,7 @@
 			<version>2.11</version>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -48,10 +48,10 @@
 							!org.openstack4j.connectors.jersey2,
 							*
 						</Import-Package>
-						<!-- 
+						<!--
 						Required for SPI in OSGi:
 						http://aries.apache.org/modules/spi-fly.html#specconf
-						
+
 						This bundle defines an implementation for following services in META-INF-services:
 						org.openstack4j.core.transport.HttpExecutorService
 						 -->
@@ -62,6 +62,18 @@
 							osgi.serviceloader; osgi.serviceloader=org.openstack4j.core.transport.HttpExecutorService
 						</Provide-Capability>
 					</instructions>
+				</configuration>
+			</plugin>
+
+			<!-- JDK 1.8 required by this connector (https://github.com/ContainX/openstack4j/issues/673) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
@@ -18,7 +18,7 @@ import co.freeside.betamax.tape.yaml.TapePropertyUtils
 abstract class AbstractSpec extends Specification {
 
     def static String MODULEROOT = Paths.get("").toAbsolutePath().getParent().toString()
-    def static String TAPEROOT = String.join("/", MODULEROOT , "src/test/resources/tapes/")
+    def static String TAPEROOT = "/" + MODULEROOT + "src/test/resources/tapes/"
     def static Config CONFIG_PROXY_BETAMAX = Config.newConfig().withProxy(ProxyHost.of("http://localhost", 5555))
 
     // get required attributes from system environment according to python-openstackclient specification
@@ -55,9 +55,5 @@ abstract class AbstractSpec extends Specification {
         BetamaxRoutePlanner.configure(http)
 
         log.info("-> Tests using connector: " + HttpExecutor.create().getExecutorName())
-        
-        
-
     }
-
 }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,7 +19,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.pacesys.openstack4j.connectors</groupId>
-			<artifactId>openstack4j-jersey2</artifactId>
+			<artifactId>openstack4j-resteasy</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- Project depends on 1.7
- Controllers affected by [JDK-7157360](https://bugs.openjdk.java.net/browse/JDK-7157360) depends on 1.8
- `distribution` module depends on `openstack4j-resteasy`