### PR TITLE
Fixup 87237fa61a3982f41a12742f5ad15e7a6dc0efc5

### DIFF
--- a/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
@@ -18,7 +18,7 @@ import co.freeside.betamax.tape.yaml.TapePropertyUtils
 abstract class AbstractSpec extends Specification {
 
     def static String MODULEROOT = Paths.get("").toAbsolutePath().getParent().toString()
-    def static String TAPEROOT = "/" + MODULEROOT + "src/test/resources/tapes/"
+    def static String TAPEROOT = MODULEROOT + "/src/test/resources/tapes/"
     def static Config CONFIG_PROXY_BETAMAX = Config.newConfig().withProxy(ProxyHost.of("http://localhost", 5555))
 
     // get required attributes from system environment according to python-openstackclient specification


### PR DESCRIPTION
This fixes a mistake made in https://github.com/ContainX/openstack4j/pull/693.