### PR TITLE
Introduce base for micro versions

### DIFF
--- a/core-test/src/main/java/org/openstack4j/openstack/internal/MicroVersionedServiceTest.java
+++ b/core-test/src/main/java/org/openstack4j/openstack/internal/MicroVersionedServiceTest.java
@@ -1,0 +1,96 @@
+package org.openstack4j.openstack.internal;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.types.ServiceType;
+import org.openstack4j.core.transport.HttpMethod;
+import org.openstack4j.core.transport.HttpRequest;
+import org.openstack4j.openstack.internal.MicroVersion;
+import org.openstack4j.openstack.internal.MicroVersionedOpenStackService;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class MicroVersionedServiceTest extends AbstractTest {
+    private TestService service;
+    private static final MicroVersion MICRO_VERSION = new MicroVersion(1, 0);
+    private static final String API_VERSION_HEADER = "X-Openstack-Test-Api-Version";
+
+    @Override
+    protected Service service() {
+        // The service type defined here is only required to get a valid session.
+        // Because we never send a request, but only build it and check the headers,
+        // the service type defined here does not matter for the test results.
+        return Service.COMPUTE;
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        service = new TestService(ServiceType.UNKNOWN, MICRO_VERSION, API_VERSION_HEADER);
+    }
+
+    @Test
+    public void get() {
+        Map<String, Object> headers = service.get(Object.class, "path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    @Test
+    public void post() {
+        Map<String, Object> headers = service.post(Object.class, "path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    @Test
+    public void put() {
+        Map<String, Object> headers = service.put(Object.class, "path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    @Test
+    public void patch() {
+        Map<String, Object> headers = service.patch(Object.class, "path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    @Test
+    public void delete() {
+        Map<String, Object> headers = service.delete(Object.class, "path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    @Test
+    public void deleteWithResponse() {
+        Map<String, Object> headers = service.deleteWithResponse("path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    @Test
+    public void head() {
+        Map<String, Object> headers = service.head(Object.class, "path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    @Test
+    public void request() {
+        Map<String, Object> headers = service.request(HttpMethod.GET, Object.class, "path").req.build().getHeaders();
+        assertEquals(headers.get(API_VERSION_HEADER), MICRO_VERSION.toString());
+    }
+
+    private static class TestService extends MicroVersionedOpenStackService {
+        private String apiVersionHeader;
+
+        private TestService(ServiceType serviceType, MicroVersion microVersion, String apiVersionHeader) {
+            super(serviceType, microVersion);
+            this.apiVersionHeader = apiVersionHeader;
+        }
+
+        @Override
+        protected String getApiVersionHeader() {
+            return apiVersionHeader;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/api/manila/SharesService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/SharesService.java
@@ -66,6 +66,15 @@ public interface SharesService extends RestService {
     ActionResponse delete(String shareId);
 
     /**
+     * Deletes a share.
+     *
+     * @param shareId the share ID
+     * @param consistencyGroupId the UUID of the consistency group where the share was created
+     * @return the action response
+     */
+    ActionResponse delete(String shareId, String consistencyGroupId);
+
+    /**
      * Shows the metadata for a share.
      *
      * @param shareId the share ID

--- a/core/src/main/java/org/openstack4j/openstack/internal/MicroVersion.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/MicroVersion.java
@@ -1,0 +1,61 @@
+package org.openstack4j.openstack.internal;
+
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Common representation of an API micro version.
+ *
+ * @author Daniel Gonzalez Nothnagel
+ */
+public class MicroVersion implements Comparable<MicroVersion> {
+    private final static Pattern VERSION_REGEX = Pattern.compile("^([1-9]\\d*)\\.([1-9]\\d*|0|)$");
+
+    private final int majorVersion;
+    private final int minorVersion;
+
+    public MicroVersion(String version) {
+        Matcher versionMatcher = VERSION_REGEX.matcher(version);
+
+        if (!versionMatcher.matches()) {
+            throw new IllegalArgumentException(String.format(
+                    "Invalid version pattern %s, should be 'X.Y' (Major.Minor)", version));
+        }
+
+        majorVersion = Integer.valueOf(versionMatcher.group(1));
+        minorVersion = Integer.valueOf(versionMatcher.group(2));
+    }
+
+    public MicroVersion(int majorVersion, int minorVersion) {
+        this.majorVersion = majorVersion;
+        this.minorVersion = minorVersion;
+    }
+
+    @Override
+    public int compareTo(MicroVersion o) {
+        int majorDifference = majorVersion - o.majorVersion;
+        if (majorDifference != 0) {
+            return majorDifference;
+        }
+
+        return minorVersion - o.minorVersion;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof MicroVersion) {
+            MicroVersion v = (MicroVersion) obj;
+            return compareTo(v) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d", majorVersion, minorVersion);
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/internal/MicroVersionedOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/MicroVersionedOpenStackService.java
@@ -1,0 +1,76 @@
+package org.openstack4j.openstack.internal;
+
+import com.google.common.base.Function;
+import org.openstack4j.api.types.ServiceType;
+import org.openstack4j.core.transport.HttpMethod;
+import org.openstack4j.model.common.ActionResponse;
+
+/**
+ * Base class for OpenStack services which use micro-versions.
+ *
+ * @author Daniel Gonzalez Nothnagel
+ */
+public abstract class MicroVersionedOpenStackService extends BaseOpenStackService {
+    private final MicroVersion microVersion;
+
+    protected MicroVersionedOpenStackService(MicroVersion microVersion) {
+        this.microVersion = microVersion;
+    }
+
+    protected MicroVersionedOpenStackService(ServiceType serviceType, MicroVersion microVersion) {
+        super(serviceType);
+        this.microVersion = microVersion;
+    }
+
+    protected MicroVersionedOpenStackService(ServiceType serviceType, MicroVersion microVersion,
+                                             Function<String, String> endpointFunc) {
+        super(serviceType, endpointFunc);
+        this.microVersion = microVersion;
+    }
+
+    private MicroVersion getMicroVersion() {
+        return microVersion;
+    }
+
+    protected abstract String getApiVersionHeader();
+
+    @Override
+    protected <R> Invocation<R> get(Class<R> returnType, String... path) {
+        return super.get(returnType, path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+
+    @Override
+    protected <R> Invocation<R> post(Class<R> returnType, String... path) {
+        return super.post(returnType, path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+
+    @Override
+    protected <R> Invocation<R> put(Class<R> returnType, String... path) {
+        return super.put(returnType, path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+
+    @Override
+    protected <R> Invocation<R> patch(Class<R> returnType, String... path) {
+        return super.patch(returnType, path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+
+    @Override
+    protected <R> Invocation<R> delete(Class<R> returnType, String... path) {
+        return super.delete(returnType, path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+
+    @Override
+    protected <R> Invocation<ActionResponse> deleteWithResponse(String... path) {
+        return super.deleteWithResponse(path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+
+    @Override
+    protected <R> Invocation<R> head(Class<R> returnType, String... path) {
+        return super.head(returnType, path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+
+    @Override
+    protected <R> Invocation<R> request(HttpMethod method, Class<R> returnType, String path) {
+        return super.request(method, returnType, path).header(getApiVersionHeader(), getMicroVersion().toString());
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/BaseShareServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/BaseShareServices.java
@@ -1,10 +1,27 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.types.ServiceType;
-import org.openstack4j.openstack.internal.BaseOpenStackService;
+import org.openstack4j.openstack.internal.MicroVersion;
+import org.openstack4j.openstack.internal.MicroVersionedOpenStackService;
 
-public class BaseShareServices extends BaseOpenStackService {
+public class BaseShareServices extends MicroVersionedOpenStackService {
+    private final static String API_VERSION_HEADER = "X-Openstack-Manila-Api-Version";
+
+    private static final MicroVersion LIBERTY_VERSION = new MicroVersion(2, 6);
+    private static final MicroVersion MITAKA_VERSION = new MicroVersion(2, 15);
+    // At the moment, 2.6 is the latest micro-version supported by OpenStack4j. So set it as default.
+    private static final MicroVersion DEFAULT_VERSION = LIBERTY_VERSION;
+
+    protected BaseShareServices(MicroVersion version) {
+        super(ServiceType.SHARE, version);
+    }
+
     protected BaseShareServices() {
-        super(ServiceType.SHARE);
+        this(DEFAULT_VERSION);
+    }
+
+    @Override
+    protected String getApiVersionHeader() {
+        return API_VERSION_HEADER;
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/SharesServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/SharesServiceImpl.java
@@ -88,6 +88,15 @@ public class SharesServiceImpl extends BaseShareServices implements SharesServic
                 delete(Void.class, uri("/shares/%s", shareId)).executeWithResponse());
     }
 
+    @Override
+    public ActionResponse delete(String shareId, String consistencyGroupId) {
+        checkNotNull(shareId);
+        return ToActionResponseFunction.INSTANCE.apply(
+                delete(Void.class, uri("/shares/%s", shareId))
+                        .param(consistencyGroupId != null, "consistency_group_id ", consistencyGroupId)
+                        .executeWithResponse());
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/core/src/test/java/org/openstack4j/test/common/MicroVersionTest.java
+++ b/core/src/test/java/org/openstack4j/test/common/MicroVersionTest.java
@@ -1,0 +1,62 @@
+package org.openstack4j.test.common;
+
+import org.openstack4j.openstack.internal.MicroVersion;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class MicroVersionTest {
+    @DataProvider
+    public static Object[][] invalidMicroVersions() {
+        return new Object[][] {
+                {"1.2.3"},
+                {"1,0"},
+                {"1"},
+                {"version"},
+                {"0.1"}
+        };
+    }
+
+    @Test
+    public void createFromString() {
+        MicroVersion microVersion = new MicroVersion("1.1");
+        assertEquals(microVersion, new MicroVersion(1, 1));
+    }
+
+    @Test(dataProvider = "invalidMicroVersions")
+    public void createInvalidFromString(String v) {
+        try {
+            new MicroVersion(v);
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid version pattern " + v + ", should be 'X.Y' (Major.Minor)");
+        }
+    }
+
+    @Test
+    public void equals() {
+        MicroVersion v = new MicroVersion(1, 0);
+
+        assertTrue(v.equals(new MicroVersion(1, 0)));
+        assertTrue(v.equals(new MicroVersion("1.0")));
+        assertTrue(v.equals(v));
+        assertFalse(v.equals(new MicroVersion(1, 1)));
+        assertFalse(v.equals(null));
+        assertFalse(v.equals(new Object()));
+    }
+
+    @Test
+    public void compareTo() {
+        MicroVersion v10 = new MicroVersion(1, 0);
+        MicroVersion v11 = new MicroVersion(1, 1);
+        MicroVersion v20 = new MicroVersion(2, 0);
+
+        assertTrue(v10.compareTo(v11) < 0);
+        assertTrue(v20.compareTo(v11) > 0);
+        assertTrue(v11.compareTo(v11) == 0);
+    }
+
+
+}


### PR DESCRIPTION
Many OpenStack Services, like nova and manila, use micro-versions for their APIs.

This PR introduces a new base class for micro-versioned services, which will send an HTTP header specifying the desired micro-version with each API request.

Omitting this HTTP header causes the API to fall back to its minimum version (e.g. 2.1 for nova, 2.0 for manila), which prevents OpenStack4j to use newer API features.

This PR also includes a patch which enables micro-versions for manila. The latest version supported in this patch is 2.6, which equals the latest micro-version supported in Liberty. I will continue to work on supporting newer API versions (the latest micro-version for manila is 2.15 at the moment).

Please note that I consider this PR as a basis for discussion and that I am open for suggestions on how to improve this design. For example, there is no way for the user to specify which micro-version to use.