### PR TITLE
travis configuration for only jdk1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,13 @@ jdk:
   - oraclejdk7
   - openjdk7
 
-env:
-  global:
-    - SKIP_JDK8_MODULES='-pl !org.pacesys.openstack4j.connectors:openstack4j-http-connector,!org.pacesys.openstack4j.connectors:openstack4j-jersey2,!org.pacesys:it-jersey2'
-
-matrix:
-  include:
-    - jdk: "oraclejdk8"
-      env: SKIP_JDK8_MODULES=""
-
 notifications:
   email: false
 
+
 install: /bin/true
 
-# When run on JDK7, modules that require JDK8 needs to be skipped
-script: mvn clean verify -B $SKIP_JDK8_MODULES
+script: "mvn clean verify -pl '!org.pacesys.openstack4j.connectors:openstack4j-http-connector,!org.pacesys.openstack4j.connectors:openstack4j-jersey2,!org.pacesys:it-jersey2'"
 
 # whitelist
 branches:


### PR DESCRIPTION
For now taking @olivergondza's working solution to get os4j back to green on jdk1.7 . 

I'll look into getting the integration tests with jdk1.8 back again.