### PR TITLE
Fix URL for manila back-end storage pools in maintenance

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/SchedulerStatsServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/SchedulerStatsServiceImpl.java
@@ -18,7 +18,7 @@ public class SchedulerStatsServiceImpl extends BaseShareServices implements Sche
     }
 
     private List<? extends BackendStoragePool> list(boolean detail) {
-        return get(ManilaBackendStoragePool.BackendStoragePools.class, uri("/pools" +  (detail ? "/detail" : "")))
+        return get(ManilaBackendStoragePool.BackendStoragePools.class, uri("/scheduler-stats/pools" +  (detail ? "/detail" : "")))
                 .execute()
                 .getList();
     }


### PR DESCRIPTION
This patch resolves #719 for the maintenance branch