### PR TITLE
Fix #734: add extra field on project

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneProjectServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneProjectServiceTests.java
@@ -22,7 +22,10 @@ public class KeystoneProjectServiceTests extends AbstractTest {
     private static final String PROJECT_DOMAIN_ID = "7a71863c2d1d4444b3e6c2cd36955e1e";
     private static final String PROJECT_DESCRIPTION = "Project used for CRUD tests";
     private static final String PROJECT_DESCRIPTION_UPDATE = "An updated project used for CRUD tests";
-	
+    private static final String PROJECT_EXTRA_KEY_1 = "extra_key1";
+    private static final String PROJECT_EXTRA_VALUE_1 = "value1";
+    private static final String PROJECT_EXTRA_KEY_2 = "extra_key2";
+    private static final String PROJECT_EXTRA_VALUE_2 = "value2";
     private String PROJECT_ID;
 
     @Override
@@ -46,7 +49,7 @@ public class KeystoneProjectServiceTests extends AbstractTest {
     public void projects_crud_test() throws Exception {
 
         Project project = Builders.project().name(PROJECT_NAME).description(PROJECT_DESCRIPTION)
-                .domainId(PROJECT_DOMAIN_ID).enabled(true).build();
+                .domainId(PROJECT_DOMAIN_ID).setExtra(PROJECT_EXTRA_KEY_1, PROJECT_EXTRA_VALUE_1).enabled(true).build();
 
         respondWith(JSON_PROJECTS_CREATE);
 
@@ -55,6 +58,7 @@ public class KeystoneProjectServiceTests extends AbstractTest {
         assertEquals(newProject.getName(), PROJECT_NAME);
         assertEquals(newProject.getDomainId(), PROJECT_DOMAIN_ID);
         assertEquals(newProject.getDescription(), PROJECT_DESCRIPTION);
+        assertEquals(newProject.getExtra(PROJECT_EXTRA_KEY_1), PROJECT_EXTRA_VALUE_1);
 
         PROJECT_ID = newProject.getId();
 
@@ -64,14 +68,17 @@ public class KeystoneProjectServiceTests extends AbstractTest {
 
         respondWith(JSON_PROJECTS_UPDATE);
 
-        Project updatedProject = osv3().identity().projects()
-                .update(project_setToUpdate.toBuilder().description(PROJECT_DESCRIPTION_UPDATE).build());
+        Project updatedProject = osv3().identity().projects().update(
+                project_setToUpdate.toBuilder().description(PROJECT_DESCRIPTION_UPDATE)
+                        .setExtra(PROJECT_EXTRA_KEY_2, PROJECT_EXTRA_VALUE_2)
+                        .build());
 
         assertEquals(updatedProject.getId(), PROJECT_ID);
         assertEquals(updatedProject.getName(), PROJECT_NAME);
         assertEquals(updatedProject.getDomainId(), PROJECT_DOMAIN_ID);
         assertEquals(updatedProject.getDescription(), PROJECT_DESCRIPTION_UPDATE);
-
+        assertEquals(updatedProject.getExtra(PROJECT_EXTRA_KEY_1), PROJECT_EXTRA_VALUE_1);
+        assertEquals(updatedProject.getExtra(PROJECT_EXTRA_KEY_2), PROJECT_EXTRA_VALUE_2);
     }
     
     public void projects_getByName_not_exist_test() throws Exception {

--- a/core-test/src/main/resources/identity/v3/projects_create_response.json
+++ b/core-test/src/main/resources/identity/v3/projects_create_response.json
@@ -9,6 +9,7 @@
     "id": "3337151a1c38496c8bffcb280b19c346",
     "parent_id": null,
     "domain_id": "7a71863c2d1d4444b3e6c2cd36955e1e",
-    "name": "ProjectX"
+    "name": "ProjectX",
+    "extra_key1": "value1"
   }
 }

--- a/core-test/src/main/resources/identity/v3/projects_update_response.json
+++ b/core-test/src/main/resources/identity/v3/projects_update_response.json
@@ -9,6 +9,8 @@
     "id": "3337151a1c38496c8bffcb280b19c346",
     "parent_id": null,
     "domain_id": "7a71863c2d1d4444b3e6c2cd36955e1e",
-    "name": "ProjectX"
+    "name": "ProjectX",
+    "extra_key1": "value1",
+    "extra_key2": "value2"
   }
 }

--- a/core/src/main/java/org/openstack4j/model/identity/v3/Project.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/Project.java
@@ -72,4 +72,9 @@ public interface Project extends ModelEntity, Buildable<ProjectBuilder> {
      */
     boolean isEnabled();
 
+    /**
+     *
+     * @return value for the given key
+     */
+    String getExtra(String key);
 }

--- a/core/src/main/java/org/openstack4j/model/identity/v3/builder/ProjectBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/builder/ProjectBuilder.java
@@ -71,4 +71,9 @@ public interface ProjectBuilder extends Builder<ProjectBuilder, Project> {
      */
     ProjectBuilder parents(String parents);
 
+    /**
+     *
+     * @see Project#getExtra(String)
+     */
+    ProjectBuilder setExtra(String name, String value);
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
@@ -1,16 +1,15 @@
 package org.openstack4j.openstack.identity.v3.domain;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.*;
 import org.openstack4j.model.identity.v3.Domain;
 import org.openstack4j.model.identity.v3.Project;
 import org.openstack4j.model.identity.v3.builder.ProjectBuilder;
 import org.openstack4j.openstack.common.ListResult;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.Objects;
 
 /**
@@ -19,7 +18,8 @@ import com.google.common.base.Objects;
  * @see <a href="http://developer.openstack.org/api-ref-identity-v3.html#projects-v3">API reference</a>
  */
 @JsonRootName("project")
-@JsonIgnoreProperties(ignoreUnknown = true)
+/** If we don't explicitly set extra as an ignore property, it will methods with @JsonAnyGetter/Setter will not work **/
+@JsonIgnoreProperties(value = "extra" , ignoreUnknown = true)
 public class KeystoneProject implements Project {
 
     private static final long serialVersionUID = 1L;
@@ -32,12 +32,14 @@ public class KeystoneProject implements Project {
     @JsonProperty("domain_id")
     private String domainId;
     private String description;
+    @JsonIgnore
     private Map<String, String> links;
     @JsonProperty("parent_id")
     private String parentId;
     private String subtree;
     private String parents;
     private Boolean enabled = true;
+    private Map<String, String> extra = new HashMap<String, String>();
 
     /**
      * @return the Project builder
@@ -96,9 +98,18 @@ public class KeystoneProject implements Project {
     /**
      * {@inheritDoc}
      */
+    @JsonIgnore
     @Override
     public Map<String, String> getLinks() {
         return links;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @JsonProperty("links")
+    public void setLinks(Map<String, String> links) {
+        this.links = links;
     }
 
     /**
@@ -131,6 +142,29 @@ public class KeystoneProject implements Project {
     @Override
     public boolean isEnabled() {
         return (enabled != null && enabled);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getExtra(String key) {
+        return extra.get(key);
+    }
+
+    @JsonAnyGetter
+    public Map<String, String> getExtra() {
+        return extra;
+    }
+
+    @JsonAnySetter
+    public void setExtra(String key, String value) {
+        // is_domain is not necessary
+        // if we don't ignore this, this will be set into extra field.
+        if (Objects.equal(key, "is_domain")) {
+            return;
+        }
+        extra.put(key, value);
     }
 
     /**
@@ -278,6 +312,16 @@ public class KeystoneProject implements Project {
         @Override
         public ProjectBuilder parents(String parents) {
             model.parents = parents;
+            return this;
+        }
+
+
+        /**
+         * @see KeystoneProject#setExtra(String, String)
+         */
+        @Override
+        public ProjectBuilder setExtra(String key, String value) {
+            model.extra.put(key, value);
             return this;
         }
 


### PR DESCRIPTION
This includes the fix for #734 "add extra field on project

To support extra field, I have modified org.openstack4j.openstack.identity.v3.domain.KeystoneProject like followings.

* Put ```
    private Map<String, String> extra = new HashMap<String, String>();``` in the KeystoneProject
* Create getExtra / setExtra with ```@JsonAnyGetter``` and ```@JsonAnySetter``` which are called when there are no explicitly mapped field.
* Ignore __is_domain__ field in setExtra which is automatically calculated field from keystone. Currently openstack4j just ignores this field. However with this patch if we don't ignore this in setExtra, it will be re-sent to the keystone during project update call and keystone will keep this in DB's extra fields.
* Put @JsonIgnore on getLinks(), because if it's re-sent to keystone while project update, it will be interpreted as extra field just like __is_domain__.
* Put ```@JsonIgnoreProperties(value = "extra" , ignoreUnknown = true)``` on  KeystoneProject class. If we don't provide this on KeystoneProject class, ```private Map<String, String> extra = new HashMap<String, String>(); ``` will be translated to ``` "extra": {  ....  }```. This is not working in IdentityV3. Puting ```@JsonIgnore``` on ```private Map<String, String> extra = new HashMap<String, String>(); ```  doesn't not working for @JsonAnyGetter and @JsonAnySetter as well. I found that this is the only way not to send extra field to keystone.

You can not find the exact blueprint for this in keystone but I can find relevant [the blueprint](https://blueprints.launchpad.net/horizon/+spec/support-extra-prop-for-project-and-user) in horizon.

Because it's only visible when the additional field is input, there is not much examples in OpenStack IdentityV3 spec. 

You can fine the some evidence in the following. __is_domain__ field.
http://developer.openstack.org/api-ref-identity-v3.html#updateProject