### PR TITLE
Fix integrationtests

### DIFF
--- a/core-integration-test/README.md
+++ b/core-integration-test/README.md
@@ -1,16 +1,23 @@
 openstack4j-integrationtest
 ===========================
 
-integration tests for openstack4j's identity (keystone) v3 written in groovy using spock testframework and betamax to record/replay server-client communication
+Integration tests for openstack4j's identity (keystone) v3 written in groovy using spock testframework and betamax to record/replay server-client communication
 
 HOW TO
 ------
-* tests are executed in integration-test phase. Do a ```mvn clean integration-test``` or ```mvn clean install``` (or any phase later should include the ones before)
+### Run ITests
+
+* Integration tests are executed in the integration-test phase. Do a ```mvn clean integration-test``` or ```mvn clean verify``` (or any phase later) to trigger the tests.
+
+### Write ITests
+
+* Using the Spock Framework: http://spockframework.github.io/spock/docs/1.1-rc-1/index.html
+* Recording cloud interactions with Betamax: https://github.com/betamaxteam/betamax
 
 Important
 ---------
-* the tests work completely without setting the following environment variables. In which case the tapes are used in playback mode.
-* If you want to perform an integration test using another openstack instance you need to provide the following required parameters in your system environment. They are similar to the ones the python openstack-client needs. Make sure they are set or tests will be skipped. 
+* the tests work completely without setting the following environment variables. In which case the tapes are used in **playback** mode.
+* Adding or changing test cases with cloud interaction requires **recording** by providing the following required parameters in your system environment. They are similar to the ones the python openstack-client needs. Make sure they are set or tests will be skipped.
 * attributes used: (incomplete)
 	* OS_AUTH_URL = ``` "http://<fqdn>:5000/v3" ```
 	* OS_USER_ID

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -11,7 +11,9 @@
 	<packaging>pom</packaging>
 	<properties>
 		<skipTests>false</skipTests>
-		<it-root>${session.executionRootDirectory}</it-root>
+		<!--<it-root>${session.executionRootDirectory}</it-root>-->
+		<betamax.core.version>2.1.0-20160705.041750-6</betamax.core.version>
+		<betamax.junit.version>2.1.0-SNAPSHOT</betamax.junit.version>
 	</properties>
 
 	<!-- dedicated module per connector to test -->
@@ -27,6 +29,12 @@
 			<groupId>org.pacesys</groupId>
 			<artifactId>openstack4j</artifactId>
 			<version>${project.version}</version>
+			<exclusions>
+				<exclusion> <!-- excluded to solve AbstractMethodError due to duplication of javax.ws.rs-api in the above mentioned modules -->
+					<groupId>org.pacesys.openstack4j.connectors</groupId>
+					<artifactId>openstack4j-resteasy</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -47,9 +55,15 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>co.freeside</groupId>
-			<artifactId>betamax</artifactId>
-			<version>1.1.2</version>
+			<groupId>software.betamax</groupId>
+			<artifactId>betamax-junit</artifactId>
+			<version>${betamax.junit.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>software.betamax</groupId>
+			<artifactId>betamax-core</artifactId>
+			<version>${betamax.core.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -66,6 +66,11 @@
 			<version>${betamax.core.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/AbstractSpec.groovy
@@ -1,18 +1,11 @@
 package org.openstack4j.api
 
 import java.nio.file.Paths
-import org.slf4j.*
 import groovy.util.logging.Slf4j
-import org.apache.http.impl.client.DefaultHttpClient
 import org.openstack4j.core.transport.Config
 import org.openstack4j.core.transport.ProxyHost
 import org.openstack4j.core.transport.internal.HttpExecutor
-import org.yaml.snakeyaml.introspector.Property
 import spock.lang.Specification
-import co.freeside.betamax.httpclient.BetamaxRoutePlanner
-import co.freeside.betamax.tape.yaml.OrderedPropertyComparator
-import co.freeside.betamax.tape.yaml.TapePropertyUtils
-
 
 @Slf4j
 abstract class AbstractSpec extends Specification {
@@ -45,15 +38,6 @@ abstract class AbstractSpec extends Specification {
     def static String ROLE_CRUD_ANOTHER_ROLE_ID = System.getenv('OS_ROLE_CRUD_ANOTHER_ROLE_ID') ?: '9ab55538924d45588fdb62e0e5fcbc40'
 
     def setupSpec() {
-
-        // this is needed to fix a (betamax) bug caused by version conflicts with betamax,spock,groovy
-        TapePropertyUtils.metaClass.sort = {Set<Property> properties, List<String> names ->
-            new LinkedHashSet(properties.sort(true, new OrderedPropertyComparator(names)))
-        }
-
-        final DefaultHttpClient http = new DefaultHttpClient()
-        BetamaxRoutePlanner.configure(http)
-
-        log.info("-> Tests using connector: " + HttpExecutor.create().getExecutorName())
+        log.info("Using connector: " + HttpExecutor.create().getExecutorName())
     }
 }

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneAuthenticationSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneAuthenticationSpec.groovy
@@ -8,22 +8,28 @@ import org.openstack4j.api.AbstractSpec
 import org.openstack4j.api.OSClient.OSClientV3
 import org.openstack4j.api.exceptions.RegionEndpointNotFoundException
 import org.openstack4j.api.types.ServiceType
-import org.openstack4j.core.transport.Config
 import org.openstack4j.model.common.Identifier
 import org.openstack4j.model.identity.AuthVersion
 import org.openstack4j.model.identity.v3.User
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystoneAuthenticationSpec extends AbstractSpec {
 
     @Rule TestName KeystoneAuthenticationTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     static final boolean skipTest
 

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneCredentialServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneCredentialServiceSpec.groovy
@@ -2,7 +2,6 @@ package org.openstack4j.api.identity
 
 
 import groovy.util.logging.Slf4j
-import org.apache.commons.lang.ObjectUtils
 import org.junit.Rule
 import org.junit.rules.TestName
 import org.openstack4j.api.AbstractSpec
@@ -14,16 +13,21 @@ import org.openstack4j.model.identity.v3.User
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 @Slf4j
 class KeystoneCredentialServiceSpec extends AbstractSpec {
 
-    @Rule
-    TestName KeystoneCredentialServiceTest
-    @Rule
-    Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT + "identity.v3"))
+    @Rule TestName KeystoneCredentialServiceTest
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for credential tests
     def static final String CREDENTIAL_CRUD_TYPE = "ec2"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneDomainServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneDomainServiceSpec.groovy
@@ -13,15 +13,22 @@ import org.openstack4j.model.identity.v3.Domain
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystoneDomainServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneDomainServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // used for domain crud tests
     def static String DOMAIN_CRUD_NAME = "Domain_CRUD"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneGroupServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneGroupServiceSpec.groovy
@@ -14,15 +14,22 @@ import org.openstack4j.model.common.ActionResponse
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystoneGroupServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneGroupServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for group service tests
     def static final String GROUP_CRUD_NAME = "GROUP_GRUD"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystonePolicyServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystonePolicyServiceSpec.groovy
@@ -13,15 +13,22 @@ import org.openstack4j.model.identity.v3.User
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystonePolicyServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystonePolicyServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for policy tests
     def static String POLICY_CRUD_TYPE = "application/json"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneProjectServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneProjectServiceSpec.groovy
@@ -14,14 +14,21 @@ import org.openstack4j.model.identity.v3.Project
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 @Slf4j
 class KeystoneProjectServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneProjectServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // used for project crud
     def static String PROJECT_NAME = "Project_CRUD"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneRegionServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneRegionServiceSpec.groovy
@@ -12,15 +12,22 @@ import org.openstack4j.model.identity.v3.Region
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystoneRegionServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneRegionServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for region tests
     def static String REGION_CRUD_ID = "Region_CRUD"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneRoleServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneRoleServiceSpec.groovy
@@ -13,15 +13,22 @@ import org.openstack4j.model.identity.v3.Role
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystoneRoleServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneRoleServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for role tests
     def static String ROLE_CRUD_NAME = "Role_CRUD"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneServiceEndpointServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneServiceEndpointServiceSpec.groovy
@@ -15,15 +15,22 @@ import org.openstack4j.model.identity.v3.Service
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystoneServiceEndpointServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneServiceEndpointServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for service endpoint and service tests
     def static final String SERVICE_CRUD_TYPE = "identity"

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneTokenServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneTokenServiceSpec.groovy
@@ -12,15 +12,22 @@ import org.openstack4j.model.identity.v3.Token
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Recorder
-import co.freeside.betamax.Betamax
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 
 @Slf4j
 class KeystoneTokenServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneTokenServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for token service tests
     // Unfortunately betamax stops us from generating a second USER_TOKEN (not able to record and play back) so a fixed token id is provided here.

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneUserServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/v3/KeystoneUserServiceSpec.groovy
@@ -1,7 +1,6 @@
 package org.openstack4j.api.identity.v3
 
 import groovy.util.logging.Slf4j
-
 import org.junit.Rule
 import org.junit.rules.TestName
 import org.openstack4j.api.AbstractSpec
@@ -14,15 +13,21 @@ import org.openstack4j.model.identity.v3.User
 import org.openstack4j.openstack.OSFactory
 
 import spock.lang.IgnoreIf
-import co.freeside.betamax.Betamax
-import co.freeside.betamax.Recorder
-
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.junit.RecorderRule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
 
 @Slf4j
 class KeystoneUserServiceSpec extends AbstractSpec {
 
     @Rule TestName KeystoneUserServiceTest
-    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT+"identity.v3"))
+    @Rule public RecorderRule recorder = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    .defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .build());
 
     // additional attributes for user service tests
     def static final String USER_CRUD_NAME = "foobar"
@@ -33,18 +38,17 @@ class KeystoneUserServiceSpec extends AbstractSpec {
     static final boolean skipTest
 
     static {
-        if(
+        if (
         USER_ID == null ||
-        AUTH_URL == null ||
-        PASSWORD == null ||
-        DOMAIN_ID == null ||
-        USER_DOMAIN_ID == null ||
-        PROJECT_ID == null ||
-        ANOTHER_GROUP_ID == null ) {
+                AUTH_URL == null ||
+                PASSWORD == null ||
+                DOMAIN_ID == null ||
+                USER_DOMAIN_ID == null ||
+                PROJECT_ID == null ||
+                ANOTHER_GROUP_ID == null) {
 
             skipTest = true
-        }
-        else{
+        } else {
             skipTest = false
         }
     }
@@ -52,15 +56,14 @@ class KeystoneUserServiceSpec extends AbstractSpec {
     // run before the first feature method; similar to JUnit's @BeforeClass
     def setupSpec() {
 
-        if( skipTest != true ) {
+        if (skipTest != true) {
             log.info("USER_ID: " + USER_ID)
             log.info("AUTH_URL: " + AUTH_URL)
             log.info("PASSWORD: " + PASSWORD)
             log.info("DOMAIN_ID: " + DOMAIN_ID)
             log.info("USER_DOMAIN_ID: " + USER_DOMAIN_ID)
             log.info("PROJECT_ID: " + PROJECT_ID)
-        }
-        else {
+        } else {
             log.warn("Skipping integration-test cases because not all mandatory attributes are set.")
         }
     }
@@ -69,11 +72,10 @@ class KeystoneUserServiceSpec extends AbstractSpec {
         log.info("-> Test: '$KeystoneUserServiceTest.methodName'")
     }
 
-
     // ------------ UserService Tests ------------
 
     @IgnoreIf({ skipTest })
-    @Betamax(tape="userService_user_crud.tape")
+    @Betamax(tape = "userService_user_crud.tape")
     def "create, read, update, delete user-service test cases"() {
 
         given: "authenticated v3 OSClient"
@@ -108,7 +110,7 @@ class KeystoneUserServiceSpec extends AbstractSpec {
 
         then: "check if the user is the same as requested "
         user_byName.getId() == newUser.getId()
-        user_byName.getName() ==  USER_CRUD_NAME
+        user_byName.getName() == USER_CRUD_NAME
         user_byName.getEmail() == USER_CRUD_EMAIL
         user_byName.isEnabled() == true
         user_byName.getDomainId() == USER_DOMAIN_ID
@@ -152,12 +154,12 @@ class KeystoneUserServiceSpec extends AbstractSpec {
         //        updatedUser.isEnabled() == true
         //        updatedUser.getId() == USER_CRUD_ID
         //        updatedUser.getDomainId() == USER_DOMAIN_ID
-		
-		when: "an non-existing user is 'read' by name and domain"
-		User userByName_nonExistent = os.identity().users().getByName("nonExistentUserName", USER_DOMAIN_ID)
-		
-		then: "this should return null"
-		userByName_nonExistent == null
+
+        when: "an non-existing user is 'read' by name and domain"
+        User userByName_nonExistent = os.identity().users().getByName("nonExistentUserName", USER_DOMAIN_ID)
+
+        then: "this should return null"
+        userByName_nonExistent == null
 
         when: "roles for an existing user in domain context are requested"
         List<? extends Role> domainUserRolesList = os.identity().users().listDomainUserRoles(USER_ID, USER_DOMAIN_ID)


### PR DESCRIPTION
*Finally* this fixes the bug in the it-module caused by different sorting of query paramteres in jdk1.7 and jdk1.8 by
- upgrading betamax to latest snapshot version
- use method, path, query params to match recordings in the tapes 

other:
- slightly updated the readme in integration-test module
- re-enable logging by adding missing dependency

@ContainX/openstack4j
