### PR TITLE
API provider microversion support

### DIFF
--- a/core/src/main/java/org/openstack4j/api/APIProvider.java
+++ b/core/src/main/java/org/openstack4j/api/APIProvider.java
@@ -1,5 +1,8 @@
 package org.openstack4j.api;
 
+import org.openstack4j.common.MicroVersionedRestService;
+import org.openstack4j.openstack.internal.MicroVersion;
+
 /**
  * To keep our dependencies simple in the current Openstack4J, we utilize ServiceLoader to load a provider who is responsible
  * for loading the implementation for any of the defined API interfaces.  This allows us to avoid pulling in extra 3rd party 
@@ -24,4 +27,15 @@ public interface APIProvider {
 	 * @throws ApiNotFoundException if the API cannot be found
 	 */
 	<T> T get(Class<T> api);
+
+	/**
+	 * Gets the implementation for the specified interface type in the given micro version
+	 *
+	 * @param <T> the Openstack4j API type
+	 * @param api the API interface
+	 * @param version the micro version to use
+	 * @return the implementation for T
+	 * @throws ApiNotFoundException if the API cannot be found
+	 */
+	<T extends MicroVersionedRestService> T get(Class<T> api, MicroVersion version);
 }

--- a/core/src/main/java/org/openstack4j/api/Apis.java
+++ b/core/src/main/java/org/openstack4j/api/Apis.java
@@ -9,6 +9,8 @@ import org.openstack4j.api.image.ImageService;
 import org.openstack4j.api.manila.ShareService;
 import org.openstack4j.api.networking.NetworkingService;
 import org.openstack4j.api.sahara.SaharaService;
+import org.openstack4j.common.MicroVersionedRestService;
+import org.openstack4j.openstack.internal.MicroVersion;
 
 /**
  * Provides access to the Major APIs and Buildables
@@ -30,6 +32,21 @@ public class Apis {
      */
     public static <T> T get(Class<T> api) {
         return provider.get(api);
+    }
+
+    /**
+     * Gets the API implementation based on Type and version
+     *
+     * @param <T>
+     *            the API type
+     * @param api
+     *            the API implementation
+     * @param version
+     *            the API micro version
+     * @return the API implementation
+     */
+    public static <T extends MicroVersionedRestService> T get(Class<T> api, MicroVersion version) {
+        return provider.get(api, version);
     }
 
     /**
@@ -102,6 +119,16 @@ public class Apis {
      */
     public static ShareService getShareServices() {
         return get(ShareService.class);
+    }
+
+    /**
+     * Gets the (Manila) Shared File Systems services API with the given micro version
+     *
+     * @param version the micro version to use for the service
+     * @return the share services
+     */
+    public static ShareService getShareServices(MicroVersion version) {
+        return get(ShareService.class, version);
     }
 
 	/**

--- a/core/src/main/java/org/openstack4j/api/OSClient.java
+++ b/core/src/main/java/org/openstack4j/api/OSClient.java
@@ -17,6 +17,7 @@ import org.openstack4j.api.types.Facing;
 import org.openstack4j.api.types.ServiceType;
 import org.openstack4j.model.identity.v2.Access;
 import org.openstack4j.model.identity.v3.Token;
+import org.openstack4j.openstack.internal.MicroVersion;
 
 /**
  * A client which has been identified. Any calls spawned from this session will
@@ -180,6 +181,14 @@ public interface OSClient< T extends OSClient<T>> {
      * @return the share service
      */
     ShareService share();
+
+    /**
+     * Returns the Shared File Systems API for the given API micro version
+     *
+     * @param version the micro version to use for the API
+     * @return the share service
+     */
+    ShareService share(MicroVersion version);
 
     /**
      * Returns the Heat Service API

--- a/core/src/main/java/org/openstack4j/api/manila/QuotaSetService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/QuotaSetService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.QuotaSet;
 import org.openstack4j.model.manila.QuotaSetUpdateOptions;
@@ -10,7 +10,7 @@ import org.openstack4j.model.manila.QuotaSetUpdateOptions;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface QuotaSetService extends RestService {
+public interface QuotaSetService extends MicroVersionedRestService {
     /**
      * Shows quotas for a tenant.
      *

--- a/core/src/main/java/org/openstack4j/api/manila/SchedulerStatsService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/SchedulerStatsService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.manila.BackendStoragePool;
 
 import java.util.List;
@@ -10,7 +10,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface SchedulerStatsService extends RestService {
+public interface SchedulerStatsService extends MicroVersionedRestService {
     /**
      * Lists all back-end storage pools.
      *

--- a/core/src/main/java/org/openstack4j/api/manila/SecurityServiceService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/SecurityServiceService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.SecurityService;
 import org.openstack4j.model.manila.SecurityServiceCreate;
@@ -14,7 +14,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface SecurityServiceService extends RestService {
+public interface SecurityServiceService extends MicroVersionedRestService {
     /**
      * Creates a security service.
      *

--- a/core/src/main/java/org/openstack4j/api/manila/ShareInstanceService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareInstanceService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareInstance;
 
@@ -11,7 +11,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface ShareInstanceService extends RestService {
+public interface ShareInstanceService extends MicroVersionedRestService {
     /**
      * Lists all share instances.
      *

--- a/core/src/main/java/org/openstack4j/api/manila/ShareNetworkService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareNetworkService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareNetwork;
 import org.openstack4j.model.manila.ShareNetworkCreate;
@@ -14,7 +14,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface ShareNetworkService extends RestService {
+public interface ShareNetworkService extends MicroVersionedRestService {
 
     /**
      * Creates a share network.

--- a/core/src/main/java/org/openstack4j/api/manila/ShareServerService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareServerService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareServer;
 
@@ -11,7 +11,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface ShareServerService extends RestService {
+public interface ShareServerService extends MicroVersionedRestService {
     /**
      * Lists all share servers.
      *

--- a/core/src/main/java/org/openstack4j/api/manila/ShareService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareService.java
@@ -1,8 +1,8 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
-import org.openstack4j.model.common.Extension;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.common.Extension;
 import org.openstack4j.model.manila.*;
 import org.openstack4j.openstack.manila.domain.ManilaService;
 
@@ -13,7 +13,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface ShareService extends RestService {
+public interface ShareService extends MicroVersionedRestService {
     /**
      * @return a list of available Shared File Systems API extensions
      */

--- a/core/src/main/java/org/openstack4j/api/manila/ShareSnapshotService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareSnapshotService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareSnapshot;
 import org.openstack4j.model.manila.ShareSnapshotCreate;
@@ -13,7 +13,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface ShareSnapshotService extends RestService {
+public interface ShareSnapshotService extends MicroVersionedRestService {
     /**
      * Creates a snapshot from a share.
      *

--- a/core/src/main/java/org/openstack4j/api/manila/ShareTypeService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareTypeService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ExtraSpecs;
 import org.openstack4j.model.manila.ShareType;
@@ -14,7 +14,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface ShareTypeService extends RestService {
+public interface ShareTypeService extends MicroVersionedRestService {
     /**
      * Creates a share type.
      *

--- a/core/src/main/java/org/openstack4j/api/manila/SharesService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/SharesService.java
@@ -1,6 +1,6 @@
 package org.openstack4j.api.manila;
 
-import org.openstack4j.common.RestService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.Access;
 import org.openstack4j.model.manila.Share;
@@ -17,7 +17,7 @@ import java.util.List;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public interface SharesService extends RestService {
+public interface SharesService extends MicroVersionedRestService {
     /**
      * Creates a share.
      *

--- a/core/src/main/java/org/openstack4j/common/MicroVersionedRestService.java
+++ b/core/src/main/java/org/openstack4j/common/MicroVersionedRestService.java
@@ -1,0 +1,21 @@
+package org.openstack4j.common;
+
+import org.openstack4j.openstack.internal.MicroVersion;
+
+/**
+ * An API decorator which is a rest consumer for APIs which support micro versions.
+ *
+ * @author Daniel Gonzalez Nothnagel
+ */
+public interface MicroVersionedRestService extends RestService {
+    /**
+     * @return the micro version used to query the rest service
+     */
+    MicroVersion getMicroVersion();
+
+    /**
+     * Set the micro version to query the rest service with.
+     * @param microVersion the micro version to use for queries
+     */
+    void setMicroVersion(MicroVersion microVersion);
+}

--- a/core/src/main/java/org/openstack4j/openstack/internal/MicroVersionedOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/MicroVersionedOpenStackService.java
@@ -2,6 +2,7 @@ package org.openstack4j.openstack.internal;
 
 import com.google.common.base.Function;
 import org.openstack4j.api.types.ServiceType;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.core.transport.HttpMethod;
 import org.openstack4j.model.common.ActionResponse;
 
@@ -10,8 +11,9 @@ import org.openstack4j.model.common.ActionResponse;
  *
  * @author Daniel Gonzalez Nothnagel
  */
-public abstract class MicroVersionedOpenStackService extends BaseOpenStackService {
-    private final MicroVersion microVersion;
+public abstract class MicroVersionedOpenStackService extends BaseOpenStackService
+        implements MicroVersionedRestService {
+    private MicroVersion microVersion;
 
     protected MicroVersionedOpenStackService(MicroVersion microVersion) {
         this.microVersion = microVersion;
@@ -28,8 +30,14 @@ public abstract class MicroVersionedOpenStackService extends BaseOpenStackServic
         this.microVersion = microVersion;
     }
 
-    private MicroVersion getMicroVersion() {
+    @Override
+    public MicroVersion getMicroVersion() {
         return microVersion;
+    }
+
+    @Override
+    public void setMicroVersion(MicroVersion microVersion) {
+        this.microVersion = microVersion;
     }
 
     protected abstract String getApiVersionHeader();

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -143,6 +143,13 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
     /**
      * {@inheritDoc}
      */
+    public ShareService share(MicroVersion version) {
+        return Apis.get(ShareService.class, version);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public HeatService heat() {
         return Apis.getHeatServices();
     }

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServiceImpl.java
@@ -43,7 +43,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      * {@inheritDoc}
      */
     public SharesService shares() {
-        return Apis.get(SharesService.class);
+        return Apis.get(SharesService.class, getMicroVersion());
     }
 
     /**
@@ -51,7 +51,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public SecurityServiceService securityServices() {
-        return Apis.get(SecurityServiceService.class);
+        return Apis.get(SecurityServiceService.class, getMicroVersion());
     }
 
     /**
@@ -59,7 +59,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public ShareSnapshotService shareSnapshots() {
-        return Apis.get(ShareSnapshotService.class);
+        return Apis.get(ShareSnapshotService.class, getMicroVersion());
     }
 
     /**
@@ -67,7 +67,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public ShareNetworkService shareNetworks() {
-        return Apis.get(ShareNetworkService.class);
+        return Apis.get(ShareNetworkService.class, getMicroVersion());
     }
 
     /**
@@ -75,7 +75,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public ShareServerService shareServers() {
-        return Apis.get(ShareServerService.class);
+        return Apis.get(ShareServerService.class, getMicroVersion());
     }
 
     /**
@@ -83,7 +83,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public ShareInstanceService shareInstances() {
-        return Apis.get(ShareInstanceService.class);
+        return Apis.get(ShareInstanceService.class, getMicroVersion());
     }
 
     /**
@@ -91,7 +91,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public ShareTypeService shareTypes() {
-        return Apis.get(ShareTypeService.class);
+        return Apis.get(ShareTypeService.class, getMicroVersion());
     }
 
     /**
@@ -99,7 +99,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public SchedulerStatsService schedulerStats() {
-        return Apis.get(SchedulerStatsService.class);
+        return Apis.get(SchedulerStatsService.class, getMicroVersion());
     }
 
     /**
@@ -172,6 +172,6 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public QuotaSetService quotaSets() {
-        return Apis.get(QuotaSetService.class);
+        return Apis.get(QuotaSetService.class, getMicroVersion());
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
+++ b/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
@@ -106,6 +106,7 @@ import org.openstack4j.api.telemetry.EventService;
 import org.openstack4j.api.telemetry.MeterService;
 import org.openstack4j.api.telemetry.SampleService;
 import org.openstack4j.api.telemetry.TelemetryService;
+import org.openstack4j.common.MicroVersionedRestService;
 import org.openstack4j.openstack.compute.internal.ComputeFloatingIPServiceImpl;
 import org.openstack4j.openstack.compute.internal.ComputeImageServiceImpl;
 import org.openstack4j.openstack.compute.internal.ComputeSecurityGroupServiceImpl;


### PR DESCRIPTION
This PR adds support to the APIProvider to create and maintain services in certain micro versions. This allows users to specify which micro version they want to use for their service.

It also contains the necessary code to use this with manila. SO users can specify their desired micro version like this:

``` java
ShareService shareService = os.share(new MicroVersion(2, 6));
```
