### PR TITLE
proposed apis for lbaas v2 support

### DIFF
--- a/core/src/main/java/org/openstack4j/api/networking/NetworkingService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/NetworkingService.java
@@ -1,6 +1,7 @@
 package org.openstack4j.api.networking;
 
 import org.openstack4j.api.networking.ext.FirewallAsService;
+import org.openstack4j.api.networking.ext.LbaasV2Service;
 import org.openstack4j.api.networking.ext.LoadBalancerService;
 import org.openstack4j.api.networking.ext.NetQuotaService;
 import org.openstack4j.common.RestService;
@@ -58,7 +59,12 @@ public interface NetworkingService extends RestService {
      * @return the LBaaS service
      */
     LoadBalancerService loadbalancers();
-    
+
+    /**
+     * @return the LBaaS V2 service
+     */
+    LbaasV2Service lbaasV2();
+
     /**
      * <p>OpenStack Firewall As a Service <code>(FwaaS) : Firewall</code> Operations API</p>
      * 

--- a/core/src/main/java/org/openstack4j/api/networking/ext/HealthMonitorV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/HealthMonitorV2Service.java
@@ -1,0 +1,11 @@
+package org.openstack4j.api.networking.ext;
+
+import org.openstack4j.common.RestService;
+
+/**
+ * Networking (Neutron Lbaas) V2 healthmonitor Extention API
+ * @author emjburns
+ */
+public interface HealthMonitorV2Service extends RestService {
+    // TODO: add support for lbaas v2 health monitors
+}

--- a/core/src/main/java/org/openstack4j/api/networking/ext/HealthMonitorV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/HealthMonitorV2Service.java
@@ -1,11 +1,58 @@
 package org.openstack4j.api.networking.ext;
 
 import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.HealthMonitorV2;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Networking (Neutron Lbaas) V2 healthmonitor Extention API
  * @author emjburns
  */
 public interface HealthMonitorV2Service extends RestService {
-    // TODO: add support for lbaas v2 health monitors
+    /**
+     * List all healthMonitor  that the current tenant has access to
+     *
+     * @return list of all healthMonitorV2
+     */
+    List<? extends HealthMonitorV2> list();
+
+    /**
+     * Returns list of healthMonitorV2 filtered by parameters.
+     *
+     * @param filteringParams map (name, value) of filtering parameters
+     * @return
+     */
+    List<? extends HealthMonitorV2> list(Map<String, String> filteringParams);
+
+    /**
+     * Get the specified healthMonitorV2 by ID
+     *
+     * @param healthMonitorId the healthMonitorV2 identifier
+     * @return the healthMonitorV2 or null if not found
+     */
+    HealthMonitorV2 get(String healthMonitorId);
+
+    /**
+     * Delete the specified healthMonitor by ID
+     * @param healthMonitorId the healthMonitorV2 identifier
+     * @return the action response
+     */
+    ActionResponse delete(String healthMonitorId);
+    /**
+     * Create a healthMonitorV2
+     * @param healthMonitor
+     * @return HealthMonitorV2
+     */
+    HealthMonitorV2 create(HealthMonitorV2 healthMonitor);
+    /**
+     * Update a healthMonitorV2
+     * @param healthMonitorId the healthMonitorV2 identifier
+     * @param healthMonitor HealthMonitorV2Update
+     * @return HealthMonitorV2
+     */
+//    TODO: impl update
+//    HealthMonitorV2 update(String healthMonitorId,HealthMonitorV2Update healthMonitor);
 }

--- a/core/src/main/java/org/openstack4j/api/networking/ext/LbPoolV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/LbPoolV2Service.java
@@ -1,0 +1,11 @@
+package org.openstack4j.api.networking.ext;
+
+import org.openstack4j.common.RestService;
+
+/**
+ * Networking (Neutron) Lbaas V2 pool Extension API
+ * @author emjburns
+ */
+public interface LbPoolV2Service extends RestService {
+    // TODO: add support for lbaas v2 pools
+}

--- a/core/src/main/java/org/openstack4j/api/networking/ext/LbPoolV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/LbPoolV2Service.java
@@ -1,11 +1,69 @@
 package org.openstack4j.api.networking.ext;
 
 import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.LbPoolV2;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Networking (Neutron) Lbaas V2 pool Extension API
  * @author emjburns
  */
 public interface LbPoolV2Service extends RestService {
-    // TODO: add support for lbaas v2 pools
+    /**
+     * List all lb pools that the current tenant has access to
+     *
+     * @return list of all lb pools
+     */
+    List<? extends LbPoolV2> list();
+
+    /**
+     * Returns list of lb v2 pools filtered by parameters.
+     *
+     * @param filteringParams
+     *            map (name, value) of filtering parameters
+     * @return List
+     */
+    List<? extends LbPoolV2> list(Map<String, String> filteringParams);
+
+    /**
+     * Get the specified lb pool by ID
+     *
+     * @param lbPoolId
+     *            the lb v2 pool identifier
+     * @return the lbPoolV2 or null if not found
+     */
+    LbPoolV2 get(String lbPoolId);
+
+    /**
+     * Delete the specified lb Pool by ID
+     *
+     * @param lbPoolId
+     *            the lb pool identifier
+     * @return the action response
+     */
+    ActionResponse delete(String lbPoolId);
+
+    /**
+     * Create a lb Pool
+     *
+     * @param lbPool
+     *            LbPool
+     * @return lbPoolV2
+     */
+    LbPoolV2 create(LbPoolV2 lbPool);
+
+    /**
+     * Update a lb pool
+     *
+     * @param lbPoolId
+     *            the lb pool identifier
+     * @param lbPool
+     *            LbPoolV2Update
+     * @return LbPoolV2
+     */
+//    TODO: impl update
+//    LbPoolV2 update(String lbPoolId, LbPoolV2Update lbPool);
 }

--- a/core/src/main/java/org/openstack4j/api/networking/ext/LbaasV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/LbaasV2Service.java
@@ -24,4 +24,10 @@ public interface LbaasV2Service {
      * @return the Lbaas V2 listener Service API
      */
     ListenerService listener();
+
+    /**
+     *
+     * @return the Lbaas V2 member Service API
+     */
+    MemberV2Service memberV2();
 }

--- a/core/src/main/java/org/openstack4j/api/networking/ext/LbaasV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/LbaasV2Service.java
@@ -1,0 +1,27 @@
+package org.openstack4j.api.networking.ext;
+
+/**
+ * LBaaS (Load Balancer as a Service) V2 support
+ */
+public interface LbaasV2Service {
+
+    /**
+     * @return the Lbaas loadbalancer Service API
+     */
+    LoadBalancerV2Service loadbalancerV2();
+
+    /**
+     * @return the Lbaas healthmonitor V2 Service API
+     */
+    HealthMonitorV2Service healthMonitorV2();
+
+    /**
+     * @return the Lbaas pool Service API
+     */
+    LbPoolV2Service lbPoolV2();
+
+    /**
+     * @return the Lbaas V2 listener Service API
+     */
+    ListenerService listener();
+}

--- a/core/src/main/java/org/openstack4j/api/networking/ext/ListenerService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/ListenerService.java
@@ -1,0 +1,11 @@
+package org.openstack4j.api.networking.ext;
+
+import org.openstack4j.common.RestService;
+
+/**
+ * Networking (Neutron) Lbaas V2 listener Extension API
+ * @author emjburns
+ */
+public interface ListenerService extends RestService {
+    // TODO: add support for lbaas v2 listeners
+}

--- a/core/src/main/java/org/openstack4j/api/networking/ext/ListenerService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/ListenerService.java
@@ -1,11 +1,69 @@
 package org.openstack4j.api.networking.ext;
 
 import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.Listener;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Networking (Neutron) Lbaas V2 listener Extension API
  * @author emjburns
  */
 public interface ListenerService extends RestService {
-    // TODO: add support for lbaas v2 listeners
+    /**
+     * List all listeners that the current tenant has access to
+     *
+     * @return list of all listeners
+     */
+    List<? extends Listener> list();
+
+    /**
+     * Returns list of listeners filtered by parameters.
+     *
+     * @param filteringParams
+     *            map (name, value) of filtering parameters
+     * @return List
+     */
+    List<? extends Listener> list(Map<String, String> filteringParams);
+
+    /**
+     * Get the specified listener by ID
+     *
+     * @param listenerId
+     *            the listener identifier
+     * @return the listener or null if not found
+     */
+    Listener get(String listenerId);
+
+    /**
+     * Delete the specified listener by ID
+     *
+     * @param listenerId
+     *            the listener identifier
+     * @return the action response
+     */
+    ActionResponse delete(String listenerId);
+
+    /**
+     * Create a listener
+     *
+     * @param listener
+     *            Listener
+     * @return Listener
+     */
+    Listener create(Listener listener);
+
+    /**
+     * Update a listener
+     *
+     * @param listenerId
+     *            the listener identifier
+     * @param Listener
+     *            ListenerUpdate
+     * @return Listener
+     */
+//    TODO: implement update
+//    Listener update(String listenerId, ListenerUpdate listener);
 }

--- a/core/src/main/java/org/openstack4j/api/networking/ext/LoadBalancerV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/LoadBalancerV2Service.java
@@ -1,11 +1,63 @@
 package org.openstack4j.api.networking.ext;
 
 import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.LoadBalancerV2;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Networking (Neutron Lbaas) V2 loadbalancer Extention API
  * @author emjburns
  */
 public interface LoadBalancerV2Service extends RestService {
-    // TODO: add support for lbaas v2 loadbalancers
+    /**
+     * List all loadbalancers  that the current tenant has access to
+     *
+     * @return list of all loadbalancers
+     */
+    List<? extends LoadBalancerV2> list();
+
+    /**
+     * Returns list of loadbalancers filtered by parameters.
+     *
+     * @param filteringParams map (name, value) of filtering parameters
+     * @return list of loadbalancer fitered by filteringParams
+     */
+    List<? extends LoadBalancerV2> list(Map<String, String> filteringParams);
+
+    /**
+     * Get the specified loadbalancer by ID
+     *
+     * @param loadbalancerId the loadbalancer identifier
+     * @return the loadbalancer or null if not found
+     */
+    LoadBalancerV2 get(String loadbalancerId);
+
+    /**
+     * Delete the specified loadbalancer by ID
+     * @param loadbalancerId the loadbalancer identifier
+     * @return the action response
+     */
+    ActionResponse delete(String loadbalancerId);
+    /**
+     * Create a loadbalancer
+     * @param loadbalancer
+     * @return loadbalancer
+     */
+    LoadBalancerV2 create(LoadBalancerV2 loadbalancer);
+    /**
+     * Update a loadbalancer
+     * @param loadbalancerId the loadbalancer identifier
+     * @param loadbalancer LoadBalancerV2Update
+     * @return loadbalancer
+     */
+//    TODO: implement update
+//    LoadBalancerV2 update(String loadbalancerId, LoadBalancerV2Update loadbalancer);
+
+    // TODO: loadbalancer status tree
+    //      https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0#Retrieve_a_specific_Load_Balancer.27s_Status_Tree
+    // TODO: loadbalancer statistics
+    //      https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0#Retrieve_a_specific_Load_Balancer.27s_Statistics
 }

--- a/core/src/main/java/org/openstack4j/api/networking/ext/LoadBalancerV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/LoadBalancerV2Service.java
@@ -1,0 +1,11 @@
+package org.openstack4j.api.networking.ext;
+
+import org.openstack4j.common.RestService;
+
+/**
+ * Networking (Neutron Lbaas) V2 loadbalancer Extention API
+ * @author emjburns
+ */
+public interface LoadBalancerV2Service extends RestService {
+    // TODO: add support for lbaas v2 loadbalancers
+}

--- a/core/src/main/java/org/openstack4j/api/networking/ext/MemberV2Service.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/MemberV2Service.java
@@ -1,0 +1,60 @@
+package org.openstack4j.api.networking.ext;
+
+import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.network.ext.MemberV2;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Networking (Neutron Lbaas) V2 Member Extention API
+ * @author emjburns
+ */
+public interface MemberV2Service extends RestService {
+    /**
+     * List all members  that the current tenant has access to
+     *
+     * @return list of all Member
+     */
+    List<? extends MemberV2> list();
+
+    /**
+     * Returns list of member filtered by parameters.
+     *
+     * @param filteringParams map (name, value) of filtering parameters
+     * @return
+     */
+    List<? extends MemberV2> list(Map<String, String> filteringParams);
+
+    /**
+     * Get the specified member by ID
+     *
+     * @param memberId the member identifier
+     * @return the member or null if not found
+     */
+    MemberV2 get(String memberId);
+
+    /**
+     * Delete the specified member by ID
+     * @param memberId the member identifier
+     * @return the action response
+     */
+    ActionResponse delete(String memberId);
+    /**
+     * Create a member
+     * @param member Member
+     * @return Member
+     */
+    MemberV2 create(MemberV2 member);
+
+
+    /**
+     * Update a member
+     * @param memberId the member identifier
+     * @param member MemberUpdate
+     * @return Member
+     */
+//    TODO: Impl of update
+//    MemberV2 update(String memberId,MemberV2Update member);
+}

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilders.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilders.java
@@ -184,4 +184,37 @@ public interface NetworkBuilders {
      */
     public HealthMonitorAssociateBuilder lbPoolAssociateHealthMonitor();
 
+    /**
+     * The builder to create a lb v2 member
+     *
+     * @return the Member Builder v2
+     */
+    public MemberV2Builder memberV2();
+
+    /**
+     * The builder to create a v2 loadbalancer.
+     *
+     * @return LoadBalancerV2Builder the loadbalancer v2 builder
+     */
+    public LoadBalancerV2Builder lbV2();
+
+    /**
+     * The builder to create a v2 lbPool
+     *
+     * @return LbPoolV2Builder
+     */
+    public LbPoolV2Builder lbPoolV2();
+
+    /**
+     * The builder to createa v2 lbaas listener
+     * @return ListenerBuilder
+     */
+    public ListenerBuilder listenerV2();
+
+    /**
+     * The builder to create a v2 healthMonitor
+     *
+     * @return HealthMonitorV2Builder
+     */
+    public HealthMonitorV2Builder healthMonitorV2();
 }

--- a/core/src/main/java/org/openstack4j/model/network/ext/HealthMonitorV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/HealthMonitorV2.java
@@ -1,0 +1,88 @@
+package org.openstack4j.model.network.ext;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.network.ext.builder.HealthMonitorV2Builder;
+
+import java.util.List;
+
+/**
+ * A healthMonitor of a Lbaas V2 pool
+ * @author emjburns
+ */
+public interface HealthMonitorV2 extends ModelEntity, Buildable<HealthMonitorV2Builder>{
+    /**
+     * @return id the healthMonitor identifier
+     */
+    String getId();
+
+    /**
+     * @return tenantId Owner of the VIP. Only an administrative user can
+     *         specify a tenant ID other than its own.
+     */
+    String getTenantId();
+
+    /**
+     *
+     * @return type The type of probe sent by the load balancer to verify the
+     *         member state, which is TCP, HTTP, or HTTPS.
+     */
+    HealthMonitorV2Type getType();
+
+    /**
+     * @return delay The time, in seconds, between sending probes to members.
+     */
+    Integer getDelay();
+
+    /**
+     * @return timeout The maximum number of seconds for a monitor to wait for a
+     *         connection to be established before it times out. This value must
+     *         be less than the delay value.
+     */
+    Integer getTimeout();
+
+    /**
+     * @return maxRetries Number of allowed connection failures before changing
+     *         the status of the member to INACTIVE. A valid value is from 1 to
+     *         10.
+     */
+    Integer getMaxRetries();
+
+    /**
+     * Optional.
+     *
+     * @return httpMethod The HTTP method that the monitor uses for requests.
+     */
+    String getHttpMethod();
+
+    /**
+     * Optional.
+     *
+     * @return urlPath The HTTP path of the request sent by the monitor to test
+     *         the health of a member. Must be a string beginning with a forward
+     *         slash (/).
+     */
+    String getUrlPath();
+
+    /**
+     * Optional.
+     *
+     * @return expectedCodes Expected HTTP codes for a passing HTTP(S) monitor.
+     */
+    String getExpectedCodes();
+
+    /**
+     * Optional.
+     *
+     * @return adminstateup The administrative state of the health monitor,
+     *         which is up (true) or down (false). Default true.
+     */
+    boolean isAdminStateUp();
+
+    /**
+     * The pools that this health monitor will monitor.
+     * @return pools
+     */
+    List<LbPoolV2> getPools();
+
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/HealthMonitorV2Type.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/HealthMonitorV2Type.java
@@ -1,0 +1,20 @@
+package org.openstack4j.model.network.ext;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum HealthMonitorV2Type {
+    TCP, HTTP, HTTPS;
+
+    @JsonCreator
+    public static HealthMonitorType forValue(String value) {
+        if (value != null)
+        {
+            for (HealthMonitorType s : HealthMonitorType.values()) {
+                if (s.name().equalsIgnoreCase(value)) {
+                    return s;
+                }
+            }
+        }
+        return HealthMonitorType.HTTP;
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/LbPoolV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LbPoolV2.java
@@ -1,0 +1,73 @@
+package org.openstack4j.model.network.ext;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.network.ext.builder.LbPoolV2Builder;
+
+import java.util.List;
+
+/**
+ * A v2 loadbanlance pool
+ * @author emjburns
+ */
+public interface LbPoolV2 extends ModelEntity, Buildable<LbPoolV2Builder> {
+    /**
+     * @return id. The unique ID for the pool.
+     */
+    String getId();
+
+    /**
+     * @return tenantId.
+     * Owner of the pool. Only an administrative user can specify a tenant ID other than its own.
+     */
+    String getTenantId();
+
+    /**
+     * @return Pool name. Does not have to be unique.
+     */
+    String getName();
+
+    /**
+     * @return Description for the pool.
+     */
+    String getDescription();
+
+    /**
+     * @return The protocol of the pool, which is TCP, HTTP, or HTTPS.
+     */
+    Protocol getProtocol();
+
+    /**
+     * @return The load-balancer algorithm, which is round-robin, least-connections, and so on. This value, which must be supported, is dependent on the load-balancer provider. Round-robin must be supported.
+     */
+    LbMethod getLbMethod();
+
+    /**
+     *
+     * @return SessionPersistence
+     */
+    SessionPersistence getSessionPersistence();
+
+    /**
+     * @return The administrative state of the lb pool, which is up (true) or
+     *         down (false).
+     */
+    boolean isAdminStateUp();
+
+    /**
+     * Listeners associated with the pool
+     * @return listeners associated with the pool
+     */
+    List<Listener> getListeners();
+
+
+    /**
+     * @return List of members that belong to the pool.
+     */
+    List<String> getMembers();
+
+    /**
+     * @return Health monitor associated with the pool.
+     */
+    String getHealthMonitorId();
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/Listener.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/Listener.java
@@ -1,0 +1,67 @@
+package org.openstack4j.model.network.ext;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.network.ext.builder.ListenerBuilder;
+
+import java.util.List;
+
+/**
+ * A listener for v2 loadbalancer
+ * @author emjburns
+ */
+public interface Listener extends ModelEntity, Buildable<ListenerBuilder> {
+
+    /**
+     * @return id. The unique ID for the listener.
+     */
+    String getId();
+
+    /**
+     * @return tenantId.
+     * Owner of the listener. Only an administrative user can specify a tenant ID other than its own.
+     */
+    String getTenantId();
+
+    /**
+     * @return listener name. Does not have to be unique.
+     */
+    String getName();
+
+    /**
+     * @return Description for the listener.
+     */
+    String getDescription();
+
+    /**
+     * @return The protocol of the listener, which is TCP, HTTP, or HTTPS.
+     */
+    Protocol getProtocol();
+
+    /**
+     * @return The protocol of the listener.
+     */
+    Integer getProtocolPort();
+
+    /**
+     * @return The connection limit of the listener.
+     * -1 indicates an infinite limit.
+     */
+    Integer getConnectionLimit();
+
+    /**
+     * @return The default pool id of the listener.
+     */
+    String getDefaultPoolId();
+
+    /**
+     * @return The administrative state of the listener, which is up (true) or
+     *         down (false).
+     */
+    boolean isAdminStateUp();
+
+    /**
+     * @return The loadbalancers of the listener.
+     */
+    List<LoadBalancerV2> getLoadBalancers();
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/LoadBalancerV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LoadBalancerV2.java
@@ -1,0 +1,64 @@
+package org.openstack4j.model.network.ext;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.network.ext.builder.LoadBalancerV2Builder;
+
+import java.util.List;
+
+public interface LoadBalancerV2  extends ModelEntity, Buildable<LoadBalancerV2Builder> {
+    /**
+     * @return id. The unique ID for the loadbalancer.
+     */
+    String getId();
+
+    /**
+     * @return tenantId.
+     * Owner of the loadbalancer. Only an administrative user can specify a tenant ID other than its own.
+     */
+    String getTenantId();
+
+    /**
+     * @return loadbalancer name. Does not have to be unique.
+     */
+    String getName();
+
+    /**
+     * @return Description for the loadbalancer.
+     */
+    String getDescription();
+
+    /**
+     * @return The VIP subnet id of the loadbalancer.
+     */
+    String getVIPSubnetId();
+
+    /**
+     * @return The VIP address of the loadbalancer.
+     */
+    String getVIPAddress();
+
+    /**
+     * @return The administrative state of the loadbalancer, which is up (true) or
+     *         down (false).
+     */
+    boolean isAdminStateUp();
+
+    /**
+     * @return The listeners of the loadbalancer.
+     */
+    List<Listener> getListeners();
+
+    /**
+     * @return provisioningStatus.The provisioning status of the loadbalancer. Indicates whether the
+     *         loadbalancer is provisioning.
+     *         Either ACTIVE, PENDING_CREATE or ERROR.
+     */
+    String getProvisioningStatus();
+
+    /**
+     * @return operatingStatus.The operating status of the loadbalancer. Indicates whether the
+     *         loadbalancer is operational.
+     */
+    String getOperatingStatus();
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/MemberV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/MemberV2.java
@@ -1,0 +1,48 @@
+package org.openstack4j.model.network.ext;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.network.ext.builder.MemberV2Builder;
+
+/**
+ * A member of a Lbaas V2 pool
+ * @author emjburns
+ */
+public interface MemberV2  extends ModelEntity, Buildable<MemberV2Builder> {
+    /**
+     * @return the member identifier
+     */
+    String getId();
+
+    /**
+     * @return the id of a tenant. Owner of the member.
+     */
+    String getTenantId();
+
+    /**
+     * @return address the IP address of a member
+     */
+    String getAddress();
+
+    /**
+     * @return The port on which the application is hosted.such as 80
+     */
+    Integer getProtocolPort();
+
+    /**
+     * @return Weight of member.1~256
+     */
+    Integer getWeight();
+
+    /**
+     * @return The subnet in which to access the member
+     */
+    String getSubnetId();
+
+    /**
+     * @return The administrative state of the member, which is up (true) or
+     *         down (false).
+     */
+    boolean isAdminStateUp();
+
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/HealthMonitorV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/HealthMonitorV2Builder.java
@@ -1,0 +1,94 @@
+package org.openstack4j.model.network.ext.builder;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.network.ext.HealthMonitorV2;
+import org.openstack4j.model.network.ext.HealthMonitorV2Type;
+
+public interface HealthMonitorV2Builder extends Buildable.Builder<HealthMonitorV2Builder, HealthMonitorV2> {
+    /**
+     *
+     * @param tenantId
+     *            Owner of the VIP. Only an administrative user can specify a
+     *            tenant ID other than its own.
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder tenantId(String tenantId);
+
+    /**
+     *
+     * @param type
+     *            The type of probe, which is TCP, HTTP, or HTTPS, that is
+     *            sent by the health monitor to verify the member state.
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder type(HealthMonitorV2Type type);
+
+    /**
+     *
+     * @param delay
+     *            The time, in seconds, between sending probes to members.
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder delay(Integer delay);
+
+    /**
+     *
+     * @param timeout
+     *            Time in seconds to timeout each probe.
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder timeout(Integer timeout);
+
+    /**
+     *
+     * @param maxRetries
+     *            Maximum consecutive health probe tries.
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder maxRetries(Integer maxRetries);
+
+    /**
+     *
+     * @param poolId
+     *             The pool that this health monitor will monitor
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder poolId(String poolId);
+
+    /**
+     * Optional
+     *
+     * @param httpMethod
+     *            GET/PUT/POST
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder httpMethod(String httpMethod);
+
+    /**
+     * Optional
+     *
+     * @param urlPath
+     *            Path portion of URI that will be probed if type is HTTP(S).
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder urlPath(String urlPath);
+
+    /**
+     * Optional
+     *
+     * @param expectedCodes
+     *            Expected HTTP codes for a passing HTTP(S) monitor.
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder expectedCodes(String expectedCodes);
+
+    /**
+     * Optional
+     *
+     * @param adminStateUp
+     *            The administrative state of the VIP. A valid value is true
+     *            (UP) or false (DOWN). Default is true
+     * @return HealthMonitorV2Builder
+     */
+    HealthMonitorV2Builder adminStateUp(boolean adminStateUp);
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/LbPoolV2Builder.java
@@ -1,0 +1,87 @@
+package org.openstack4j.model.network.ext.builder;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.network.ext.LbMethod;
+import org.openstack4j.model.network.ext.LbPoolV2;
+import org.openstack4j.model.network.ext.Protocol;
+import org.openstack4j.model.network.ext.SessionPersistence;
+
+/**
+ * A Builder to create a lbpoolV2
+ *
+ * @author emjburns
+ *
+ */
+public interface LbPoolV2Builder extends Buildable.Builder<LbPoolV2Builder, LbPoolV2> {
+    /**
+     * @param tenantId
+     *            Owner of the pool. Only an administrative user can specify a
+     *            tenant ID other than its own.
+     * @return LbPoolBuilder
+     */
+    LbPoolV2Builder tenantId(String tenantId);
+
+    /**
+     * Optional
+     *
+     * @param name
+     *            Pool name. Does not have to be unique.
+     * @return LbPoolBuilder
+     */
+    LbPoolV2Builder name(String name);
+
+    /**
+     * Optional
+     *
+     * @param description
+     *            Description for the pool.
+     * @return LbPoolBuilder
+     */
+    LbPoolV2Builder description(String description);
+
+    /**
+     * @param protocol
+     *            The protocol of the VIP address. A valid value is TCP, HTTP,
+     *            or HTTPS.
+     * @return LbPoolBuilder
+     */
+    LbPoolV2Builder protocol(Protocol protocol);
+
+    /**
+     * @param lbMethod
+     *            The load-balancer algorithm, which is round-robin,
+     *            least-connections, and so on. This value, which must be
+     *            supported, is dependent on the load-balancer provider. Round
+     *            robin must be supported.
+     *            Must be one of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
+     * @return LbPoolBuilder
+     */
+    LbPoolBuilder lbMethod(LbMethod lbMethod);
+
+    /**
+     * Optional
+     *
+     * @param sessionPersistence
+     *            Default value empty dictionary
+     * @return VipBuilder
+     */
+    LbPoolV2Builder sessionPersistence(SessionPersistence sessionPersistence);
+
+    /**
+     * Optional
+     *
+     * @param adminStateUp
+     *            The administrative state of the lb pool, which is up (true) or
+     *            down (false). Default value true.
+     * @return LbPoolBuilder
+     */
+    LbPoolV2Builder adminStateUp(boolean adminStateUp);
+
+    /**
+     * The listener in which this pool will become the default pool.
+     * There can only be on default pool for a listener.
+     * @param listenerId
+     * @return
+     */
+    LbPoolV2Builder listenerId(String listenerId);
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerBuilder.java
@@ -1,0 +1,75 @@
+package org.openstack4j.model.network.ext.builder;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.network.ext.Listener;
+import org.openstack4j.model.network.ext.Protocol;
+
+public interface ListenerBuilder extends Buildable.Builder<ListenerBuilder, Listener> {
+    /**
+     * @param tenantId
+     *            Owner of the listener. Only an administrative user can specify a
+     *            tenant ID other than its own.
+     * @return ListenerBuilder
+     */
+    ListenerBuilder tenantId(String tenantId);
+
+    /**
+     * The load balancer this listener will be provisioned on.
+     * A tenant can only create listeners on load balancers authorized by policy
+     * (e.g. her own load balancers).
+     * @param loadBalancerId
+     * @return ListenerBuilder
+     */
+    ListenerBuilder loadBalancerId(String loadBalancerId);
+
+    /**
+     * @param protocol
+     *            The protocol of the VIP address. A valid value is TCP, HTTP,
+     *            or HTTPS.
+     * @return ListenerBuilder
+     */
+    ListenerBuilder protocol(Protocol protocol);
+
+    /**
+     * The port in which the frontend will be listening. Must be an integer in the range of 1-65535
+     * @param protocolPort
+     * @return ListenerBuilder
+     */
+    ListenerBuilder protocolPort(Integer protocolPort);
+
+    /**
+     * Optional
+     * @param adminStateUp
+     *            The administrative state of the VIP. A valid value is true
+     *            (UP) or false (DOWN). Default is true
+     * @return ListenerBuilder
+     */
+    ListenerBuilder adminStateUp(boolean adminStateUp);
+
+    /**
+     *  Optional
+     *
+     * @param name
+     *            Pool name. Does not have to be unique.
+     * @return ListenerBuilder
+     */
+    ListenerBuilder name(String name);
+
+    /**
+     * Optional
+     *
+     * @param description
+     *            Description for the pool.
+     * @return ListenerBuilder
+     */
+    ListenerBuilder description(String description);
+
+    /**
+     * Optional
+     *
+     * The default value for this attribute will be -1, indicating an infinite limit.
+     * @param connectionLimit
+     * @return ListenerBuilder
+     */
+    ListenerBuilder connectionLimit(Integer connectionLimit);
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/LoadBalancerV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/LoadBalancerV2Builder.java
@@ -1,0 +1,62 @@
+package org.openstack4j.model.network.ext.builder;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.network.ext.LoadBalancerV2;
+
+public interface LoadBalancerV2Builder extends Buildable.Builder<LoadBalancerV2Builder, LoadBalancerV2> {
+    /**
+     * @param tenantId
+     *            Owner of the loadbalancer. Only an admin user can specify a tenant ID
+     *            other than its own.
+     * @return LoadBalancerV2Builder
+     */
+    LoadBalancerV2Builder tenantId(String tenantId);
+
+    /**
+     * Optional
+     *
+     * @param name
+     *            Human-readable name for the loadbalancer. Does not have to be unique.
+     * @return LoadBalancerV2Builder
+     */
+    LoadBalancerV2Builder name(String name);
+
+    /**
+     * Optional
+     *
+     * @param description
+     *            Human-readable description for the loadbalancer.
+     * @return LoadBalancerV2Builder
+     */
+    LoadBalancerV2Builder description(String description);
+
+    /**
+     * Optional
+     *
+     * @param VipSubnetId
+     *            The network on which to allocate the load balancer's vip address.
+     *            A tenant can only create load balancer vips on networks authorized by policy (e.g. her own networks or shared/provider networks).
+     * @return LoadBalancerV2Builder
+     */
+    LoadBalancerV2Builder subnetId(String VipSubnetId);
+
+    /**
+     * Optional
+     *
+     * @param VipAddress
+     *            The IP address of the VIP.
+     *            If provided, the system will attempt to assign the load balancer's vip address to this.
+     * @return LoadBalancerV2Builder
+     */
+    LoadBalancerV2Builder address(String VipAddress);
+
+    /**
+     * Optional
+     *
+     * @param adminStateUp
+     *            The administrative state of the VIP. A valid value is true
+     *            (UP) or false (DOWN).
+     * @return LoadBalancerV2Builder
+     */
+    LoadBalancerV2Builder adminStateUp(boolean adminStateUp);
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/MemberV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/MemberV2Builder.java
@@ -1,0 +1,58 @@
+package org.openstack4j.model.network.ext.builder;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.network.ext.MemberV2;
+
+public interface MemberV2Builder extends Buildable.Builder<MemberV2Builder, MemberV2> {
+    /**
+     * @param tenantId
+     *            Owner of the member. Only an administrative user can specify a
+     *            tenant ID other than its own.
+     * @return MemberV2Builder
+     */
+    MemberV2Builder tenantId(String tenantId);
+
+    /**
+     *
+     * @param address
+     *            The IP address of the member.
+     * @return MemberV2Builder
+     */
+    MemberV2Builder address(String address);
+
+    /**
+     * @param protocolPort
+     *            The port on which the application is hosted. A valid value
+     *            is from 1 to 65535
+     * @return MemberV2Builder
+     */
+    MemberV2Builder protocolPort(Integer protocolPort);
+
+    /**
+     * @param subnetId
+     *            The subnet in which to access the member
+     * @return MemberV2Builder
+     */
+    MemberV2Builder subnetId(String subnetId);
+
+    /**
+     * Optional
+     *
+     * @param weight
+     *           Weight of member.from 1 to 256
+     *           Default 1
+     * @return MemberV2Builder
+     */
+    MemberV2Builder weight(Integer weight);
+
+
+    /**
+     * Optional
+     *
+     * @param adminStateUp
+     *            The administrative state of the member, which is up (true) or
+     *            down (false). Default true.
+     * @return MemberV2Builder
+     */
+    MemberV2Builder adminStateUp(boolean adminStateUp);
+}

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkingServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkingServiceImpl.java
@@ -10,6 +10,7 @@ import org.openstack4j.api.networking.SecurityGroupRuleService;
 import org.openstack4j.api.networking.SecurityGroupService;
 import org.openstack4j.api.networking.SubnetService;
 import org.openstack4j.api.networking.ext.FirewallAsService;
+import org.openstack4j.api.networking.ext.LbaasV2Service;
 import org.openstack4j.api.networking.ext.LoadBalancerService;
 import org.openstack4j.api.networking.ext.NetQuotaService;
 
@@ -91,7 +92,15 @@ public class NetworkingServiceImpl implements NetworkingService {
     public LoadBalancerService loadbalancers() {
         return Apis.get(LoadBalancerService.class);
     }
-    
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LbaasV2Service lbaasV2(){
+        return Apis.get(LbaasV2Service.class);
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
I'd like to add support for v2 lbaas (v1 is currently depreciated). Issue is: https://github.com/ContainX/openstack4j/issues/585 

Here is my proposition for high level APIs. I've named the overall service LbaasV2Service because in lbaas v2 they replace "vip" with "loadbalancer". I think that the service responsible for all load balancer ("/loadbalancer/...") api calls should carry the loadbalancer name. Because of that, I've given the overall service the 'lbaas' name.

Lbaas v2 apis for reference: http://developer.openstack.org/api-ref-networking-v2-ext.html#lbaas-v2.0

@gondor please review when you get a chance. If you are open to me adding support for lbaas v2 I'll start implementing.