### PR TITLE
adding vipPortId to loadbalancer, adding container refs to listener

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/ListenerV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/ListenerV2Tests.java
@@ -58,16 +58,19 @@ public class ListenerV2Tests extends AbstractTest {
         String name = "listener1";
         String description = "";
         Protocol protocol = Protocol.HTTP;
+        String tlsContainerRef = "http://0.0.0.0:9311/v1/containers/52594300-d996-49e4-8bf1-a4e000171ad8";
         ListenerV2 create = Builders.listenerV2()
                 .adminStateUp(true)
                 .name(name)
                 .description(description)
                 .protocol(protocol)
+                .defaultTlsContainerRef(tlsContainerRef)
                 .build();
         ListenerV2 result = osv3().networking().lbaasV2().listener().create(create);
         assertEquals(result.getName(), name);
         assertEquals(result.getDescription(), description);
         assertEquals(result.getProtocol(), protocol);
+        assertEquals(result.getDefaultTlsContainerRef(), tlsContainerRef);
         assertTrue(result.isAdminStateUp());
     }
 
@@ -76,17 +79,21 @@ public class ListenerV2Tests extends AbstractTest {
         String name = "listener_updated";
         String description = "im a good listener";
         Integer connectionLimit = 20;
+        String tlsContainerRef = "http://0.0.0.0:9311/v1/containers/52594300-d996-49e4-8bf1-a4e000171ad9";
         ListenerV2Update update = Builders.listenerV2Update()
                 .adminStateUp(false)
                 .description(description)
                 .name(name)
                 .connectionLimit(connectionLimit)
+                .defaultTlsContainerRef(tlsContainerRef)
                 .build();
         ListenerV2 result = osv3().networking().lbaasV2().listener().update("c07058a9-8d84-4443-b8f5-508d0facfe10", update);
         assertFalse(result.isAdminStateUp());
         assertEquals(result.getName(), name);
         assertEquals(result.getDescription(), description);
         assertEquals(result.getConnectionLimit(), connectionLimit);
+        assertEquals(result.getDefaultTlsContainerRef(), tlsContainerRef);
+
     }
 
     public void testDeleteListenerV2() {

--- a/core-test/src/main/java/org/openstack4j/api/network/LoadBalancerV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/LoadBalancerV2Tests.java
@@ -53,6 +53,7 @@ public class LoadBalancerV2Tests extends AbstractTest {
         String id = "282b71ea-9ceb-4cd6-8881-cb511af2edb5";
         LoadBalancerV2 lb = osv3().networking().lbaasV2().loadbalancer().get(id);
         assertNotNull(lb);
+        assertNotNull(lb.getVipPortId());
         assertEquals(lb.getId(), id);
     }
 

--- a/core-test/src/main/resources/network/listenerv2.json
+++ b/core-test/src/main/resources/network/listenerv2.json
@@ -3,7 +3,7 @@
     "protocol_port": 80,
     "protocol": "HTTP",
     "description": "",
-    "default_tls_container_ref": null,
+    "default_tls_container_ref": "http://0.0.0.0:9311/v1/containers/52594300-d996-49e4-8bf1-a4e000171ad8",
     "admin_state_up": true,
     "loadbalancers": [
       {
@@ -12,7 +12,7 @@
     ],
     "tenant_id": "6f759d84e3ca496ab77f8c0ffaa0311e",
     "sni_container_refs": [
-
+      "http://0.0.0.0:9311/v1/containers/907f400c-d970-47f8-9900-db5796505e1f"
     ],
     "connection_limit": -1,
     "default_pool_id": "b7f6a49f-ebd8-43c5-b792-5748366eff21",

--- a/core-test/src/main/resources/network/listenerv2_update.json
+++ b/core-test/src/main/resources/network/listenerv2_update.json
@@ -3,7 +3,7 @@
     "protocol_port": 80,
     "protocol": "HTTP",
     "description": "im a good listener",
-    "default_tls_container_ref": null,
+    "default_tls_container_ref": "http://0.0.0.0:9311/v1/containers/52594300-d996-49e4-8bf1-a4e000171ad9",
     "admin_state_up": false,
     "loadbalancers": [
       {
@@ -12,7 +12,7 @@
     ],
     "tenant_id": "6f759d84e3ca496ab77f8c0ffaa0311e",
     "sni_container_refs": [
-
+      "http://0.0.0.0:9311/v1/containers/907f400c-d970-47f8-9900-db5796505e1f"
     ],
     "connection_limit": 20,
     "default_pool_id": "b7f6a49f-ebd8-43c5-b792-5748366eff21",

--- a/core/src/main/java/org/openstack4j/model/network/ext/LbOperatingStatus.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LbOperatingStatus.java
@@ -1,0 +1,24 @@
+package org.openstack4j.model.network.ext;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Operating status of a load balancer v2
+ */
+public enum LbOperatingStatus {
+    ONLINE,
+    OFFLINE;
+
+    @JsonCreator
+    public static LbOperatingStatus forValue(String value) {
+        if (value != null)
+        {
+            for (LbOperatingStatus s : LbOperatingStatus.values()) {
+                if (s.name().equalsIgnoreCase(value)) {
+                    return s;
+                }
+            }
+        }
+        return LbOperatingStatus.OFFLINE;
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/LbProvisioningStatus.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LbProvisioningStatus.java
@@ -1,0 +1,30 @@
+package org.openstack4j.model.network.ext;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Provisioning status of load balancer v2 object
+ */
+public enum LbProvisioningStatus {
+    ACTIVE,
+    DOWN,
+    CREATED,
+    PENDING_CREATE,
+    PENDING_UPDATE,
+    PENDING_DELETE,
+    INACTIVE,
+    ERROR;
+
+    @JsonCreator
+    public static LbProvisioningStatus forValue(String value) {
+        if (value != null)
+        {
+            for (LbProvisioningStatus s : LbProvisioningStatus.values()) {
+                if (s.name().equalsIgnoreCase(value)) {
+                    return s;
+                }
+            }
+        }
+        return LbProvisioningStatus.ERROR;
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/ListenerV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/ListenerV2.java
@@ -59,6 +59,16 @@ public interface ListenerV2 extends ModelEntity, Buildable<ListenerV2Builder> {
     String getDefaultPoolId();
 
     /**
+     * @return the default tls container ref
+     */
+    String getDefaultTlsContainerRef();
+
+    /**
+     * @return the sni container refs
+     */
+    List<String> getSniContainerRefs();
+
+    /**
      * @return The administrative state of the listener, which is up (true) or
      *         down (false).
      */

--- a/core/src/main/java/org/openstack4j/model/network/ext/ListenerV2Update.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/ListenerV2Update.java
@@ -33,4 +33,9 @@ public interface ListenerV2Update extends ModelEntity, Buildable<ListenerV2Updat
      */
     public Integer getConnectionLimit();
 
+    /**
+     * Optional
+     * @see ListenerV2#getDefaultTlsContainerRef()
+     */
+    public String getDefaultTlsContainerRef();
 }

--- a/core/src/main/java/org/openstack4j/model/network/ext/LoadBalancerV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LoadBalancerV2.java
@@ -43,6 +43,11 @@ public interface LoadBalancerV2  extends ModelEntity, Buildable<LoadBalancerV2Bu
      */
     String getVipAddress();
 
+    /***
+     * @return the vip port id of the loadbalancer
+     */
+    String getVipPortId();
+
     /**
      * @return The administrative state of the loadbalancer, which is up (true) or
      *         down (false).

--- a/core/src/main/java/org/openstack4j/model/network/ext/LoadBalancerV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/LoadBalancerV2.java
@@ -64,13 +64,13 @@ public interface LoadBalancerV2  extends ModelEntity, Buildable<LoadBalancerV2Bu
      *         loadbalancer is provisioning.
      *         Either ACTIVE, PENDING_CREATE or ERROR.
      */
-    String getProvisioningStatus();
+    LbProvisioningStatus getProvisioningStatus();
 
     /**
      * @return operatingStatus.The operating status of the loadbalancer. Indicates whether the
      *         loadbalancer is operational.
      */
-    String getOperatingStatus();
+    LbOperatingStatus getOperatingStatus();
 
     /**
      * Retrieve provider the load balancer is provisioned with

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerV2Builder.java
@@ -4,6 +4,8 @@ import org.openstack4j.common.Buildable;
 import org.openstack4j.model.network.ext.ListenerV2;
 import org.openstack4j.model.network.ext.Protocol;
 
+import java.util.List;
+
 public interface ListenerV2Builder extends Buildable.Builder<ListenerV2Builder, ListenerV2> {
     /**
      * @param tenantId
@@ -71,4 +73,22 @@ public interface ListenerV2Builder extends Buildable.Builder<ListenerV2Builder, 
      * @return ListenerV2Builder
      */
     ListenerV2Builder connectionLimit(Integer connectionLimit);
+
+    /**
+     * Optional
+     *
+     * Barbican container with tls policy
+     * @param tlsContainerRef
+     * @return ListenerV2Builder
+     */
+    ListenerV2Builder defaultTlsContainerRef(String tlsContainerRef);
+
+    /**
+     * Optional
+     *
+     * Barbican container(s) with sni certificates
+     * @param sniContainerRefs
+     * @return ListenerV2Builder
+     */
+    ListenerV2Builder sniContainerRefs(List<String> sniContainerRefs);
 }

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerV2UpdateBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerV2UpdateBuilder.java
@@ -41,7 +41,16 @@ public interface ListenerV2UpdateBuilder extends Buildable.Builder<ListenerV2Upd
      * Optional
      * The maximum number of connections allowed for the listener. Default is -1, meaning no limit.
      * @param connectionLimit
-     * @return ListenerV2Update Builder
+     * @return ListenerV2UpdateBuilder
      */
     ListenerV2UpdateBuilder connectionLimit(Integer connectionLimit);
+
+    /**
+     * Optional
+     *
+     * The tls container reference
+     * @param defaultTlsContainerRef
+     * @return ListenerV2UpdateBuilder
+     */
+    ListenerV2UpdateBuilder defaultTlsContainerRef(String defaultTlsContainerRef);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronListenerV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronListenerV2.java
@@ -58,6 +58,11 @@ public class NeutronListenerV2 implements ListenerV2 {
     @JsonProperty("admin_state_up")
     private boolean adminStateUp = true;
 
+    @JsonProperty("default_tls_container_ref")
+    private String defaultTlsContainerRef;
+
+    @JsonProperty("sni_container_refs")
+    private List<String> sniContainerRefs;
 
     /**
      * {@inheritDoc}
@@ -135,6 +140,22 @@ public class NeutronListenerV2 implements ListenerV2 {
      * {@inheritDoc}
      */
     @Override
+    public String getDefaultTlsContainerRef(){
+        return defaultTlsContainerRef;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getSniContainerRefs(){
+        return sniContainerRefs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getId(){
         return id;
     }
@@ -152,6 +173,8 @@ public class NeutronListenerV2 implements ListenerV2 {
                 .add("protocolPort", protocolPort)
                 .add("connectionLImit", connectionLimit)
                 .add("defaultPoolId", defaultPoolId)
+                .add("defaultTlsContainerRef", defaultTlsContainerRef)
+                .add("sniContainerRefs", sniContainerRefs)
                 .toString();
     }
 
@@ -243,6 +266,24 @@ public class NeutronListenerV2 implements ListenerV2 {
         @Override
         public ListenerV2Builder connectionLimit(Integer connectionLimit){
             m.connectionLimit = connectionLimit;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ListenerV2Builder sniContainerRefs(List<String> sniContainerRefs){
+            m.sniContainerRefs = sniContainerRefs;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ListenerV2Builder defaultTlsContainerRef(String tlsContainerRef){
+            m.defaultTlsContainerRef = tlsContainerRef;
             return this;
         }
     }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronListenerV2Update.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronListenerV2Update.java
@@ -30,6 +30,9 @@ public class NeutronListenerV2Update implements ListenerV2Update {
     @JsonProperty("connection_limit")
     private Integer connectionLimit;
 
+    @JsonProperty("default_tls_container_ref")
+    private String defaultTlsContainerRef;
+
     /**
      * {@inheritDoc}
      */
@@ -70,6 +73,14 @@ public class NeutronListenerV2Update implements ListenerV2Update {
         return connectionLimit;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDefaultTlsContainerRef(){
+        return defaultTlsContainerRef;
+    }
+
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
@@ -77,6 +88,7 @@ public class NeutronListenerV2Update implements ListenerV2Update {
                 .add("description", description)
                 .add("name", name)
                 .add("connectionLimit", connectionLimit)
+                .add("defaultTlsContainerRef", defaultTlsContainerRef)
                 .toString();
     }
 
@@ -141,6 +153,15 @@ public class NeutronListenerV2Update implements ListenerV2Update {
         @Override
         public ListenerV2UpdateBuilder connectionLimit(Integer connectionLimit){
             m.connectionLimit = connectionLimit;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ListenerV2UpdateBuilder defaultTlsContainerRef(String defaultTlsContainerRef){
+            m.defaultTlsContainerRef = defaultTlsContainerRef;
             return this;
         }
     }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLoadBalancerV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLoadBalancerV2.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.Objects;
+import org.openstack4j.model.network.ext.LbOperatingStatus;
+import org.openstack4j.model.network.ext.LbProvisioningStatus;
 import org.openstack4j.model.network.ext.LoadBalancerV2;
 import org.openstack4j.model.network.ext.builder.LoadBalancerV2Builder;
 import org.openstack4j.openstack.common.ListResult;
@@ -43,10 +45,10 @@ public class NeutronLoadBalancerV2 implements LoadBalancerV2 {
     private boolean adminStateUp = true;
 
     @JsonProperty("provisioning_status")
-    private String provisioningStatus;
+    private LbProvisioningStatus provisioningStatus;
 
     @JsonProperty("operating_status")
-    private String operatingStatus;
+    private LbOperatingStatus operatingStatus;
 
     private List<ListItem> listeners;
 
@@ -124,7 +126,7 @@ public class NeutronLoadBalancerV2 implements LoadBalancerV2 {
      * {@inheritDoc}
      */
     @Override
-    public String getProvisioningStatus(){
+    public LbProvisioningStatus getProvisioningStatus(){
         return provisioningStatus;
     }
 
@@ -132,7 +134,7 @@ public class NeutronLoadBalancerV2 implements LoadBalancerV2 {
      * {@inheritDoc}
      */
     @Override
-    public String getOperatingStatus(){
+    public LbOperatingStatus getOperatingStatus(){
         return operatingStatus;
     }
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLoadBalancerV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronLoadBalancerV2.java
@@ -50,6 +50,9 @@ public class NeutronLoadBalancerV2 implements LoadBalancerV2 {
 
     private List<ListItem> listeners;
 
+    @JsonProperty("vip_port_id")
+    private String vipPortId;
+
     private String provider;
 
     /**
@@ -137,6 +140,14 @@ public class NeutronLoadBalancerV2 implements LoadBalancerV2 {
      * {@inheritDoc}
      */
     @Override
+    public String getVipPortId(){
+        return vipPortId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getProvider(){
         return provider;
     }
@@ -162,6 +173,7 @@ public class NeutronLoadBalancerV2 implements LoadBalancerV2 {
                 .add("provisioningStatus", provisioningStatus)
                 .add("operatingStatus", operatingStatus)
                 .add("listeners", listeners)
+                .add("vipPortId", vipPortId)
                 .add("provider", provider)
                 .toString();
     }


### PR DESCRIPTION
I was missing vipPortId in the loadbalancer object, and the tls and sni container refs in the listener object. In my openstack liberty you can only update the defaultTlsContainerRef, so that's how I've implemented here.

@vinodborole @gondor please take a look. Thanks!