### PR TITLE
adding terminated_https to listener protocol

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/ListenerV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/ListenerV2Tests.java
@@ -6,7 +6,7 @@ import org.openstack4j.api.Builders;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.ListenerV2;
 import org.openstack4j.model.network.ext.ListenerV2Update;
-import org.openstack4j.model.network.ext.Protocol;
+import org.openstack4j.model.network.ext.ListenerProtocol;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -14,10 +14,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  *
@@ -57,7 +57,7 @@ public class ListenerV2Tests extends AbstractTest {
         respondWith(LISTENERV2_JSON);
         String name = "listener1";
         String description = "";
-        Protocol protocol = Protocol.HTTP;
+        ListenerProtocol protocol = ListenerProtocol.HTTP;
         String tlsContainerRef = "http://0.0.0.0:9311/v1/containers/52594300-d996-49e4-8bf1-a4e000171ad8";
         ListenerV2 create = Builders.listenerV2()
                 .adminStateUp(true)

--- a/core/src/main/java/org/openstack4j/model/network/ext/ListenerProtocol.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/ListenerProtocol.java
@@ -1,0 +1,27 @@
+package org.openstack4j.model.network.ext;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Protocol options for lbaas v2 listener
+ * @author emjburns
+ */
+public enum ListenerProtocol {
+    HTTP,
+    HTTPS,
+    TERMINATED_HTTPS,
+    TCP;
+
+    @JsonCreator
+    public static ListenerProtocol forValue(String value) {
+        if (value != null)
+        {
+            for (ListenerProtocol s : ListenerProtocol.values()) {
+                if (s.name().equalsIgnoreCase(value)) {
+                    return s;
+                }
+            }
+        }
+        return ListenerProtocol.HTTP;
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/ListenerV2.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/ListenerV2.java
@@ -40,7 +40,7 @@ public interface ListenerV2 extends ModelEntity, Buildable<ListenerV2Builder> {
     /**
      * @return The protocol of the listener, which is TCP, HTTP, or HTTPS.
      */
-    Protocol getProtocol();
+    ListenerProtocol getProtocol();
 
     /**
      * @return The protocol of the listener.

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerV2Builder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/ListenerV2Builder.java
@@ -2,7 +2,7 @@ package org.openstack4j.model.network.ext.builder;
 
 import org.openstack4j.common.Buildable;
 import org.openstack4j.model.network.ext.ListenerV2;
-import org.openstack4j.model.network.ext.Protocol;
+import org.openstack4j.model.network.ext.ListenerProtocol;
 
 import java.util.List;
 
@@ -21,7 +21,7 @@ public interface ListenerV2Builder extends Buildable.Builder<ListenerV2Builder, 
      *            or HTTPS.
      * @return ListenerV2Builder
      */
-    ListenerV2Builder protocol(Protocol protocol);
+    ListenerV2Builder protocol(ListenerProtocol protocol);
 
     /**
      * The port in which the frontend will be listening. Must be an integer in the range of 1-65535

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronListenerV2.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronListenerV2.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.Objects;
 import org.openstack4j.model.network.ext.ListenerV2;
-import org.openstack4j.model.network.ext.Protocol;
+import org.openstack4j.model.network.ext.ListenerProtocol;
 import org.openstack4j.model.network.ext.builder.ListenerV2Builder;
 import org.openstack4j.openstack.common.ListResult;
 
@@ -32,7 +32,7 @@ public class NeutronListenerV2 implements ListenerV2 {
     /**
      * The protocol of the VIP address. A valid value is TCP, HTTP, or HTTPS
      */
-    private Protocol protocol;
+    private ListenerProtocol protocol;
 
     /**
      * The port on which to listen to client traffic that is associated with the
@@ -108,7 +108,7 @@ public class NeutronListenerV2 implements ListenerV2 {
      * {@inheritDoc}
      */
     @Override
-    public Protocol getProtocol(){
+    public ListenerProtocol getProtocol(){
         return protocol;
     }
 
@@ -219,7 +219,7 @@ public class NeutronListenerV2 implements ListenerV2 {
          * {@inheritDoc}
          */
         @Override
-        public ListenerV2Builder protocol(Protocol protocol){
+        public ListenerV2Builder protocol(ListenerProtocol protocol){
             m.protocol = protocol;
             return this;
         }


### PR DESCRIPTION
Missing terminated_https option for listener protocol. 

@vinodborole what have you found to be the most reliable source of documentation in general for OpenStack? Struggling to figure out which is most up to date/gets maintained.