### PR TITLE
Add cinder get_pools interface for getting volume backend storage info

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/storage/SchedulerStatsGetPoolTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/SchedulerStatsGetPoolTests.java
@@ -1,0 +1,74 @@
+package org.openstack4j.api.storage;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.openstack.storage.block.domain.VolumeBackendPool;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.*;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Test cases for scheduler stats.
+ *
+ * @author Chen guofeng gf.chen40@gmail.com
+ */
+@Test(suiteName="SchedulerStatsGetPool")
+public class SchedulerStatsGetPoolTests extends AbstractTest {
+    private static final String JSON_SCHEDULER_STATS = "/storage/v2/cinder_scheduler-stats.json";
+    private static final String JSON_SCHEDULER_STATS_DETAIL = "/storage/v2/cinder_scheduler-stats_detail.json";
+
+    @Override
+    protected Service service() {
+        return Service.BLOCK_STORAGE;
+    }
+
+    @Test
+    public void pools() throws Exception {
+        respondWith(JSON_SCHEDULER_STATS);
+
+        List<? extends VolumeBackendPool> pools = osv3().blockStorage().schedulerStatsPools().pools();
+        assertEquals(pools.size(), 3);
+
+        VolumeBackendPool pool1 = pools.get(0);
+        VolumeBackendPool pool2 = pools.get(1);
+        VolumeBackendPool pool3 = pools.get(2);
+
+        assertEquals(pool1.getName(), "cinder1@generic1#GENERIC1");
+
+        assertEquals(pool2.getName(), "cinder2@unmanage1#UNMANAGE1");
+
+        assertEquals(pool3.getName(), "cinder3@ams_backend#AMS_BACKEND");
+    }
+
+    @Test
+    public void poolsDetail() throws Exception {
+        respondWith(JSON_SCHEDULER_STATS_DETAIL);
+
+        List<? extends VolumeBackendPool> pools = osv3().blockStorage().schedulerStatsPools().poolsDetail();
+        assertEquals(pools.size(), 2);
+
+        VolumeBackendPool pool4 = pools.get(0);
+        VolumeBackendPool pool5 = pools.get(1);
+
+
+        assertEquals(pool4.getName(), "pool1");
+        assertFalse(pool4.getCapabilities().getQosSupport());
+        assertEquals(pool4.getCapabilities().getDriverVersion(), "1.0.0");
+        assertEquals((long) pool4.getCapabilities().getTotalCapacityGb(), 1024);
+        assertEquals((int) pool4.getCapabilities().getReservedPercentage(), 0);
+        assertEquals((long) pool4.getCapabilities().getFreeCapacityGb(), 100);
+        assertEquals(pool4.getCapabilities().getStorageProtocol(), "iSCSI");
+
+
+        assertEquals(pool5.getName(), "pool2");
+        assertTrue(pool5.getCapabilities().getQosSupport());
+        assertEquals(pool5.getCapabilities().getDriverVersion(), "1.0.1");
+        assertEquals((long) pool5.getCapabilities().getTotalCapacityGb(), 512);
+        assertEquals((int) pool5.getCapabilities().getReservedPercentage(), 0);
+        assertEquals((long) pool5.getCapabilities().getFreeCapacityGb(), 200);
+        assertEquals(pool5.getCapabilities().getStorageProtocol(), "iSER");
+    }
+
+}

--- a/core-test/src/main/resources/storage/v2/cinder_scheduler-stats.json
+++ b/core-test/src/main/resources/storage/v2/cinder_scheduler-stats.json
@@ -1,0 +1,13 @@
+{
+  "pools": [
+    {
+      "name": "cinder1@generic1#GENERIC1"
+    },
+    {
+      "name": "cinder2@unmanage1#UNMANAGE1"
+    },
+    {
+      "name": "cinder3@ams_backend#AMS_BACKEND"
+    }
+  ]
+}

--- a/core-test/src/main/resources/storage/v2/cinder_scheduler-stats_detail.json
+++ b/core-test/src/main/resources/storage/v2/cinder_scheduler-stats_detail.json
@@ -1,0 +1,26 @@
+{
+  "pools": [
+    {
+      "name": "pool1",
+      "capabilities": {
+        "total_capacity_gb": 1024,
+        "free_capacity_gb": 100,
+        "reserved_percentage": 0,
+        "driver_version": "1.0.0",
+        "storage_protocol": "iSCSI",
+        "QoS_support": false
+      }
+    },
+    {
+      "name": "pool2",
+      "capabilities": {
+        "total_capacity_gb": 512,
+        "free_capacity_gb": 200,
+        "reserved_percentage": 0,
+        "driver_version": "1.0.1",
+        "storage_protocol": "iSER",
+        "QoS_support": true
+      }
+    }
+  ]
+}

--- a/core/src/main/java/org/openstack4j/api/Apis.java
+++ b/core/src/main/java/org/openstack4j/api/Apis.java
@@ -10,6 +10,8 @@ import org.openstack4j.api.manila.ShareService;
 import org.openstack4j.api.networking.NetworkingService;
 import org.openstack4j.api.sahara.SaharaService;
 import org.openstack4j.api.senlin.SenlinService;
+import org.openstack4j.api.storage.BlockStorageService;
+
 
 /**
  * Provides access to the Major APIs and Buildables
@@ -59,6 +61,13 @@ public class Apis {
     public static ComputeService getComputeServices() {
         return get(ComputeService.class);
     }
+
+    /**
+     * Gets the block storage services API
+     *
+     * @return the block storage services
+     */
+    public static BlockStorageService getBlockStorageServices() { return get(BlockStorageService.class); }
 
     /**
      * Gets the Network services API

--- a/core/src/main/java/org/openstack4j/api/storage/BlockStorageService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/BlockStorageService.java
@@ -35,4 +35,11 @@ public interface BlockStorageService extends RestService {
 	 * @return the quota-set service
 	 */
 	BlockQuotaSetService quotaSets();
+
+	/**
+	 * The block storage get_pools service.
+	 *
+	 * @return the block storage get_pools service
+	 */
+	SchedulerStatsGetPoolService schedulerStatsPools();
 }

--- a/core/src/main/java/org/openstack4j/api/storage/SchedulerStatsGetPoolService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/SchedulerStatsGetPoolService.java
@@ -1,0 +1,24 @@
+package org.openstack4j.api.storage;
+
+import org.openstack4j.common.RestService;
+import org.openstack4j.openstack.storage.block.domain.VolumeBackendPool;
+
+import java.util.List;
+
+/**
+ * Scheduler Stats Service for Cinder block storage.
+ *
+ * @author Chen guofeng gf.chen40@gmail.com
+ */
+public interface SchedulerStatsGetPoolService extends RestService {
+    /**
+     * Lists all Volumes back-end storage pools.
+     *
+     * @return a list of all Volumes back-end storage pools
+     */
+    List<? extends VolumeBackendPool> pools();
+
+    List<? extends VolumeBackendPool> poolsDetail();
+
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -125,7 +125,6 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
      */
     public BlockStorageService blockStorage() {
         return Apis.get(BlockStorageService.class);
-
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -124,7 +124,8 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
      * {@inheritDoc}
      */
     public BlockStorageService blockStorage() {
-        return Apis.getBlockStorageServices();
+        return Apis.get(BlockStorageService.class);
+
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -124,7 +124,7 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
      * {@inheritDoc}
      */
     public BlockStorageService blockStorage() {
-        return Apis.get(BlockStorageService.class);
+        return Apis.getBlockStorageServices();
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
+++ b/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
@@ -113,6 +113,7 @@ import org.openstack4j.api.storage.BlockVolumeService;
 import org.openstack4j.api.storage.BlockVolumeSnapshotService;
 import org.openstack4j.api.storage.BlockVolumeTransferService;
 import org.openstack4j.api.storage.CinderZoneService;
+import org.openstack4j.api.storage.SchedulerStatsGetPoolService;
 import org.openstack4j.api.storage.ObjectStorageAccountService;
 import org.openstack4j.api.storage.ObjectStorageContainerService;
 import org.openstack4j.api.storage.ObjectStorageObjectService;
@@ -233,6 +234,7 @@ import org.openstack4j.openstack.storage.block.internal.BlockVolumeServiceImpl;
 import org.openstack4j.openstack.storage.block.internal.BlockVolumeSnapshotServiceImpl;
 import org.openstack4j.openstack.storage.block.internal.BlockVolumeTransferServiceImpl;
 import org.openstack4j.openstack.storage.block.internal.CinderZoneServiceImpl;
+import org.openstack4j.openstack.storage.block.internal.SchedulerStatsGetPoolServiceImpl;
 import org.openstack4j.openstack.storage.object.internal.ObjectStorageAccountServiceImpl;
 import org.openstack4j.openstack.storage.object.internal.ObjectStorageContainerServiceImpl;
 import org.openstack4j.openstack.storage.object.internal.ObjectStorageObjectServiceImpl;
@@ -389,6 +391,8 @@ public class DefaultAPIProvider implements APIProvider {
         bind(FirewallRuleService.class, FirewallRuleServiceImpl.class);
         bind(FirewallPolicyService.class, FirewallPolicyServiceImpl.class);
         bind(NetworkPolicyService.class, NetworkPolicyServiceImpl.class);
+        bind(SchedulerStatsGetPoolService.class, SchedulerStatsGetPoolServiceImpl.class);
+
 
     }
 

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderBackendStoragePool.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderBackendStoragePool.java
@@ -1,0 +1,152 @@
+package org.openstack4j.openstack.storage.block.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.openstack4j.openstack.common.ListResult;
+
+import java.util.List;
+
+/**
+ * Represents a back-end storage pool for Cinder.
+ *
+ * @author Chen guofeng gf.chen40@gmail.com
+ *
+ */
+public class CinderBackendStoragePool implements VolumeBackendPool {
+    private String name;
+    private CinderCapabilities capabilities;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Capabilities getCapabilities() {
+        return capabilities;
+    }
+
+    public static class CinderCapabilities implements Capabilities {
+        @JsonProperty("pool_name")
+        private String poolname;
+        @JsonProperty("filter_function")
+        private String filterfunction;
+        @JsonProperty("goodness_function")
+        private String goodnessfunction;
+        @JsonProperty("total_volumes")
+        private Integer totalvolumes;
+        @JsonProperty("multiattach")
+        private Boolean multiattach;
+        @JsonProperty("provisioned_capacity_gb")
+        private Long provisionedcapacitygb;
+        @JsonProperty("timestamp")
+        private String timestamp;
+        @JsonProperty("allocated_capacity_gb")
+        private Integer allocatedcapacitygb;
+        @JsonProperty("volume_backend_name")
+        private String volumeBackendName;
+        @JsonProperty("thin_provisioning_support")
+        private Boolean thinprovisioningsupport;
+        @JsonProperty("free_capacity_gb")
+        private Long freeCapacityGb;
+        @JsonProperty("driver_version")
+        private String driverVersion;
+        @JsonProperty("location_info")
+        private String locationinfo;
+        @JsonProperty("total_capacity_gb")
+        private Long totalCapacityGb;
+        @JsonProperty("thick_provisioning_support")
+        private Boolean thickprovisioningsupport;
+        @JsonProperty("reserved_percentage")
+        private Integer reservedPercentage;
+        @JsonProperty("QoS_support")
+        private Boolean qosSupport;
+        @JsonProperty("max_over_subscription_ratio")
+        private Long maxoversubscription_ratio;
+        @JsonProperty("vendor_name")
+        private String vendorname;
+        private String pools;
+        @JsonProperty("storage_protocol")
+        private String storageProtocol;
+
+
+
+        @Override
+        public String getPoolname() {
+            return poolname;
+        }
+
+        @Override
+        public String getGoodnessfunction() { return goodnessfunction; }
+        @Override
+        public Integer getTotalvolumes() {
+            return totalvolumes;
+        }
+        @Override
+        public Boolean getMultiattach() { return multiattach; }
+        @Override
+        public Long getProvisionedcapacitygb() { return provisionedcapacitygb; }
+        @Override
+        public String getTimestamp() { return timestamp; }
+        @Override
+        public Integer getAllocatedcapacitygb() { return allocatedcapacitygb; }
+
+        @Override
+        public Boolean getThinprovisioningsupport() { return thinprovisioningsupport; }
+        @Override
+        public String getLocationinfo() { return locationinfo; }
+        @Override
+        public Boolean getThickprovisioningsupport() { return thickprovisioningsupport; }
+        @Override
+        public Long getMaxoversubscription_ratio() { return maxoversubscription_ratio; }
+        @Override
+        public String getvendorname() { return vendorname; }
+        @Override
+        public String getFilterfunction() { return filterfunction; }
+        @Override
+        public Boolean getQosSupport() {
+            return qosSupport;
+        }
+
+        @Override
+        public String getVolumeBackendName() {
+            return volumeBackendName;
+        }
+
+        @Override
+        public String getDriverVersion() {
+            return driverVersion;
+        }
+
+        @Override
+        public Long getTotalCapacityGb() {
+            return totalCapacityGb;
+        }
+
+        @Override
+        public Long getFreeCapacityGb() {
+            return freeCapacityGb;
+        }
+
+        @Override
+        public Integer getReservedPercentage() {
+            return reservedPercentage;
+        }
+
+        @Override
+        public String getStorageProtocol() {
+            return storageProtocol;
+        }
+    }
+
+    public static class VolumeBackendPools extends ListResult<CinderBackendStoragePool> {
+        private static final long serialVersionUID = 1L;
+
+        @JsonProperty("pools")
+        private List<CinderBackendStoragePool> pools;
+
+        @Override
+        protected List<CinderBackendStoragePool> value() {
+            return pools;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/VolumeBackendPool.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/VolumeBackendPool.java
@@ -1,0 +1,125 @@
+package org.openstack4j.openstack.storage.block.domain;
+
+import org.openstack4j.model.ModelEntity;
+
+
+/**
+ * Represents a back-end storage pool of Cinder Volume.
+ *
+ * @author Chen guofeng gf.chen40@gmail.com
+ */
+public interface VolumeBackendPool extends ModelEntity {
+
+    /**
+     * @return the name of the back end in this format: <code>host@backend#POOL</code>
+     */
+    String getName();
+
+    /**
+     * @return the capabilities for the storage back end
+     */
+    Capabilities getCapabilities();
+
+    interface Capabilities {
+        /**
+         * @return the pool name
+         */
+        String getPoolname();
+
+        /**
+         * @return the goodness function
+         */
+        String getGoodnessfunction();
+
+        /**
+         * @return the total number of volumes
+         */
+        Integer getTotalvolumes();
+
+        /**
+         * @return the multi attach info
+         */
+        Boolean getMultiattach();
+
+        /**
+         * @return the provisioned capacity in GB
+         */
+        Long getProvisionedcapacitygb();
+
+        /**
+         * @return the timestamp of creation
+         */
+        String getTimestamp();
+
+        /**
+         * @return the allocated capacity in GB
+         */
+        Integer getAllocatedcapacitygb();
+
+        /**
+         * @return the support of thin provisioning
+         */
+        Boolean getThinprovisioningsupport();
+
+        /**
+         * @return the location info
+         */
+        String getLocationinfo();
+
+        /**
+         * @return the support of thick provisioning
+         */
+        Boolean getThickprovisioningsupport();
+
+        /**
+         * @return the ratio of Max over subscription
+         */
+        Long getMaxoversubscription_ratio();
+
+        /**
+         * @return the vendor name
+         */
+        String getvendorname();
+
+        /**
+         * @return the filter function
+         */
+        String getFilterfunction();
+
+
+        /**
+         * @return the quality of service (QoS) support
+         */
+        Boolean getQosSupport();
+
+        /**
+         * @return the name of the share back end
+         */
+        String getVolumeBackendName();
+
+        /**
+         * @return the driver version
+         */
+        String getDriverVersion();
+
+        /**
+         * @return the total capacity for the back end, in GBs, or 'unkown'
+         */
+        Long getTotalCapacityGb();
+
+        /**
+         * @return the amount of free capacity for the back end, in GBs, or 'unknown'
+         */
+        Long getFreeCapacityGb();
+
+        /**
+         * @return the percentage of the total capacity that is reserved for the internal use by the back end
+         */
+        Integer getReservedPercentage();
+
+        /**
+         * @return the storage protocol for the back end
+         */
+        String getStorageProtocol();
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockStorageServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockStorageServiceImpl.java
@@ -8,6 +8,7 @@ import org.openstack4j.api.storage.BlockVolumeSnapshotService;
 import org.openstack4j.api.storage.CinderZoneService;
 import org.openstack4j.model.storage.block.BlockLimits;
 import org.openstack4j.openstack.storage.block.domain.CinderBlockLimits;
+import org.openstack4j.api.storage.SchedulerStatsGetPoolService;
 
 /**
  * Block Storage (Cinder) Service Operation implementation
@@ -53,5 +54,11 @@ public class BlockStorageServiceImpl extends BaseBlockStorageServices implements
     {
        return Apis.get(CinderZoneService.class); 
     }
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public SchedulerStatsGetPoolService schedulerStatsPools() { return Apis.get(SchedulerStatsGetPoolService.class); }
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/internal/SchedulerStatsGetPoolServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/internal/SchedulerStatsGetPoolServiceImpl.java
@@ -1,0 +1,32 @@
+package org.openstack4j.openstack.storage.block.internal;
+
+import org.openstack4j.api.storage.SchedulerStatsGetPoolService;
+import org.openstack4j.openstack.storage.block.domain.CinderBackendStoragePool;
+import org.openstack4j.openstack.storage.block.domain.VolumeBackendPool;
+
+import java.util.List;
+
+/**
+ * Scheduler Stats Service for Cinder block storage.
+ *
+ * @author Chen guofeng gf.chen40@gmail.com
+ */
+public class SchedulerStatsGetPoolServiceImpl extends BaseBlockStorageServices implements SchedulerStatsGetPoolService {
+
+    @Override
+    public List<? extends VolumeBackendPool> pools() {
+        return list(false);
+    }
+
+    @Override
+    public List<? extends VolumeBackendPool> poolsDetail() {
+        return list(true);
+    }
+
+    private List<? extends VolumeBackendPool> list(boolean detail) {
+        return get(CinderBackendStoragePool.VolumeBackendPools.class, uri("/scheduler-stats/get_pools"))
+                .param("detail" , detail)
+                .execute()
+                .getList();
+    }
+}


### PR DESCRIPTION
#762 
Author: chenguofeng
Email：gf.chen40@gmail.com

Add support of the following RESTful API:
GET/v2/​{tenant_id}​/scheduler-stats/get_pools
GET/v2/​{tenant_id}​/scheduler-stats/get_pools?detail=True