### PR TITLE
Add query capabilities to new ceilometer sample

### DIFF
--- a/core/src/main/java/org/openstack4j/api/telemetry/SampleService.java
+++ b/core/src/main/java/org/openstack4j/api/telemetry/SampleService.java
@@ -4,11 +4,14 @@ import java.util.List;
 
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.telemetry.Sample;
+import org.openstack4j.model.telemetry.SampleCriteria;
 
 
 public interface SampleService extends RestService{
 	
 	List<? extends Sample> list();
+
+	List<? extends Sample> list(SampleCriteria criteria);
 	
 	Sample get(String sampleId);
 }

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/internal/SampleServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/internal/SampleServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.openstack4j.api.telemetry.SampleService;
 import org.openstack4j.model.telemetry.Sample;
+import org.openstack4j.model.telemetry.SampleCriteria;
 import org.openstack4j.openstack.telemetry.domain.CeiloMeterSample;
 
 /**
@@ -16,12 +17,33 @@ import org.openstack4j.openstack.telemetry.domain.CeiloMeterSample;
 
 public class SampleServiceImpl extends BaseTelemetryServices implements SampleService {
 
+    private static final String FIELD = "q.field";
+    private static final String OPER = "q.op";
+    private static final String VALUE = "q.value";
+
     /**
      * {@inheritDoc}
      */
     @Override
     public List<? extends Sample> list() {
         CeiloMeterSample[] samples = get(CeiloMeterSample[].class, uri("/samples")).execute();
+        return wrapList(samples);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends Sample> list(SampleCriteria criteria) {
+        Invocation<CeiloMeterSample[]> invocation = get(CeiloMeterSample[].class, uri("/samples"));
+        if (criteria != null && !criteria.getCriteriaParams().isEmpty()) {
+            for (SampleCriteria.NameOpValue c : criteria.getCriteriaParams()) {
+                invocation.param(FIELD, c.getField());
+                invocation.param(OPER, c.getOperator().getQueryValue());
+                invocation.param(VALUE, c.getValue());
+            }
+        }
+        CeiloMeterSample[] samples = invocation.execute();
         return wrapList(samples);
     }
 


### PR DESCRIPTION
The newly implemented ceilometer sample api (https://github.com/ContainX/openstack4j/pull/748) did not come with the query capabilities (https://github.com/ContainX/openstack4j/issues/154). This minor patch should fix that. 