### PR TITLE
Added Tacker Vnf - Attributes  & TackerError Propagation..

### DIFF
--- a/core/src/main/java/org/openstack4j/core/transport/functions/ParseActionResponseFromJsonMap.java
+++ b/core/src/main/java/org/openstack4j/core/transport/functions/ParseActionResponseFromJsonMap.java
@@ -17,6 +17,7 @@ public class ParseActionResponseFromJsonMap implements Function<Map<String, Obje
     private static final String KEY_MESSAGE = "message";
     private static final String NEUTRON_ERROR = "NeutronError";
     private static final String COMPUTE_FAULT = "computeFault";
+    private static final String TACKER_ERROR = "TackerError";
     private HttpResponse response;
     
     public ParseActionResponseFromJsonMap(HttpResponse response) {
@@ -52,6 +53,11 @@ public class ParseActionResponseFromJsonMap implements Function<Map<String, Obje
                     String msg = String.valueOf(map.get(COMPUTE_FAULT));
                     return ActionResponse.actionFailed(msg, response.getStatus());
                  }
+                if (inner.containsKey(TACKER_ERROR)) {
+                	/** For 'TackerError' Error Message Propagation.. */
+                    String msg = String.valueOf(inner.get(TACKER_ERROR));
+                    return ActionResponse.actionFailed(msg, response.getStatus());
+                }
             }
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/tacker/domain/VnfAttributes.java
+++ b/core/src/main/java/org/openstack4j/openstack/tacker/domain/VnfAttributes.java
@@ -29,6 +29,65 @@ public class VnfAttributes {
 	@JsonProperty("failure_policy")
 	private String failurePolicy;
 	
+	public static VnfAttributes create() {
+		return new VnfAttributes();
+	}
+	
+	/**
+	 * serviceType to Set..
+	 * 
+	 * @param serviceType the serviceType to set
+	 * @return VnfAttributes
+	 */
+	public VnfAttributes serviceType(String serviceType) {
+		this.serviceType = serviceType;
+		return this;
+	}
+	
+	/**
+	 * paramValues to Set..
+	 * 
+	 * @param paramValues the paramValues to set
+	 * @return VnfAttributes
+	 */
+	public VnfAttributes paramValues(String paramValues) {
+		this.paramValues = paramValues;
+		return this;
+	}
+	
+	/**
+	 * heatTemplate to Set..
+	 * 
+	 * @param heatTemplate the heatTemplate to set
+	 * @return VnfAttributes
+	 */
+	public VnfAttributes heatTemplate(String heatTemplate) {
+		this.heatTemplate = heatTemplate;
+		return this;
+	}
+	
+	/**
+	 * monitoringPolicy to Set..
+	 * 
+	 * @param monitoringPolicy the monitoringPolicy to set
+	 * @return VnfAttributes
+	 */
+	public VnfAttributes monitoringPolicy(String monitoringPolicy) {
+		this.monitoringPolicy = monitoringPolicy;
+		return this;
+	}
+	
+	/**
+	 * failurePolicy to Set..
+	 * 
+	 * @param failurePolicy the failurePolicy to set
+	 * @return VnfAttributes
+	 */
+	public VnfAttributes failurePolicy(String failurePolicy) {
+		this.failurePolicy = failurePolicy;
+		return this;
+	}
+	
 	@Override
 	public String toString() {
 		return Objects.toStringHelper(this).omitNullValues()
@@ -48,24 +107,10 @@ public class VnfAttributes {
 	}
 
 	/**
-	 * @param serviceType the serviceType to set
-	 */
-	public void setServiceType(String serviceType) {
-		this.serviceType = serviceType;
-	}
-
-	/**
 	 * @return the paramValues
 	 */
 	public String getParamValues() {
 		return paramValues;
-	}
-
-	/**
-	 * @param paramValues the paramValues to set
-	 */
-	public void setParamValues(String paramValues) {
-		this.paramValues = paramValues;
 	}
 
 	/**
@@ -76,13 +121,6 @@ public class VnfAttributes {
 	}
 
 	/**
-	 * @param heatTemplate the heatTemplate to set
-	 */
-	public void setHeatTemplate(String heatTemplate) {
-		this.heatTemplate = heatTemplate;
-	}
-
-	/**
 	 * @return the monitoringPolicy
 	 */
 	public String getMonitoringPolicy() {
@@ -90,23 +128,9 @@ public class VnfAttributes {
 	}
 
 	/**
-	 * @param monitoringPolicy the monitoringPolicy to set
-	 */
-	public void setMonitoringPolicy(String monitoringPolicy) {
-		this.monitoringPolicy = monitoringPolicy;
-	}
-
-	/**
 	 * @return the failurePolicy
 	 */
 	public String getFailurePolicy() {
 		return failurePolicy;
-	}
-
-	/**
-	 * @param failurePolicy the failurePolicy to set
-	 */
-	public void setFailurePolicy(String failurePolicy) {
-		this.failurePolicy = failurePolicy;
 	}
 }

--- a/core/src/main/java/org/openstack4j/openstack/tacker/internal/VimServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/tacker/internal/VimServiceImpl.java
@@ -66,7 +66,7 @@ public class VimServiceImpl extends BaseTackerServices implements VimService {
 	 */
 	@Override
 	public Vim register(Vim vim) {
-		return post(TackerVim.class, uri("/vims")).entity(vim).execute(ExecutionOptions.<TackerVim>create(PropagateOnStatus.on(404)));
+		return post(TackerVim.class, uri("/vims")).entity(vim).execute(ExecutionOptions.<TackerVim>create(PropagateOnStatus.on(500)));
 	}
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/tacker/internal/VnfServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/tacker/internal/VnfServiceImpl.java
@@ -67,7 +67,7 @@ public class VnfServiceImpl extends BaseTackerServices implements VnfService {
 	 */
 	@Override
 	public Vnf create(Vnf vnf) {
-		return post(TackerVnf.class, uri("/vnfs")).entity(vnf).execute(ExecutionOptions.<TackerVnf>create(PropagateOnStatus.on(404)));
+		return post(TackerVnf.class, uri("/vnfs")).entity(vnf).execute(ExecutionOptions.<TackerVnf>create(PropagateOnStatus.on(500)));
 	}
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/tacker/internal/VnfdServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/tacker/internal/VnfdServiceImpl.java
@@ -63,6 +63,6 @@ public class VnfdServiceImpl extends BaseTackerServices implements VnfdService {
 
 	@Override
 	public Vnfd create(Vnfd vnfd) {
-		return post(TackerVnfd.class, uri("/vnfds")).entity(vnfd).execute(ExecutionOptions.<TackerVnfd>create(PropagateOnStatus.on(404)));
+		return post(TackerVnfd.class, uri("/vnfds")).entity(vnfd).execute(ExecutionOptions.<TackerVnfd>create(PropagateOnStatus.on(500)));
 	}
 }


### PR DESCRIPTION
##### Added `Tacker Vnf - Attributes` - Static `Create` method..
* Added missing `Tacker Vnf` `static create()` method for setting `Vnf Attributes`..
* This can then be set in `VnfBuilder attributes(VnfAttributes attributes);`

##### Added `TackerError` Propagation..
* `TackerError` is now propagated..
* Currently `propagating` for `register - vim`, `create - vnf` and `create vnfd` calls on status `500`..
* Currently there is no way to propagate `404` status as well.. **Can this be enhanced**?
 * `create` method (with param `PropagateOnStatus`) only propagates on the provided `status code`..