### PR TITLE
Update links: gondor -> ContainX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ Bug Fixes and New Features
 --------------------------
 
 Before starting to write code, look for existing [tickets]
-(https://github.com/gondor/openstack4j/issues?state=open) or [create one]
-(https://github.com/gondor/openstack4j/issues/new) 
+(https://github.com/ContainX/openstack4j/issues?state=open) or [create one]
+(https://github.com/ContainX/openstack4j/issues/new) 
 for your bug, issue, or feature request. This helps the community
 avoid working on something that might not be of interest or which
 has already been addressed.
@@ -31,7 +31,7 @@ Chat With Me
 ------------
 
 If you want to work on something or have questions / complaints please reach
-out to me by creating a Question issue at https://github.com/gondor/openstack4j/issues/new or better yet join our group at http://groups.google.com/group/openstack4j
+out to me by creating a Question issue at https://github.com/ContainX/openstack4j/issues/new or better yet join our group at http://groups.google.com/group/openstack4j
 
 Thank you for your support!
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OpenStack4j is a fluent OpenStack client that allows provisioning and control of
 * Questions - [Stackoverflow](http://stackoverflow.com/search?q=openstack4j)
 * Twitter: [@openstack4j](https://twitter.com/openstack4j)
 * Facebook: [facebook.com/openstack4j](http://www.facebook.com/openstack4j)
-* Changelog: [Changelog](https://github.com/gondor/openstack4j/blob/master/CHANGELOG.md)
+* Changelog: [Changelog](https://github.com/ContainX/openstack4j/blob/master/CHANGELOG.md)
 
 ## Bug Reports
 
@@ -45,7 +45,7 @@ OpenStack4j version 2.0.0+ is now modular.  One of the benefits to this is the a
 
 **Using OpenStack4j with one of our connector modules**
 
-To configure OpenStack4j to use one of our supported connectors (Jersey 2, Resteasy, Apache HttpClient, OKHttp) [see the usage guide](https://github.com/gondor/openstack4j/tree/master/connectors)
+To configure OpenStack4j to use one of our supported connectors (Jersey 2, Resteasy, Apache HttpClient, OKHttp) [see the usage guide](https://github.com/ContainX/openstack4j/tree/master/connectors)
 
 #### Current (Master Branch)
 
@@ -78,7 +78,7 @@ Example POM based repository declaration to grab snapshots:
 
 Contributing
 ------------
-If you would like to contribute please see our contributing [guidelines](https://github.com/gondor/openstack4j/blob/master/CONTRIBUTING.md)
+If you would like to contribute please see our contributing [guidelines](https://github.com/ContainX/openstack4j/blob/master/CONTRIBUTING.md)
 
 #### Top 15 Contributors
 
@@ -102,7 +102,7 @@ If you would like to contribute please see our contributing [guidelines](https:/
 
 #### Throughput
 
-[![Throughput Graph](https://graphs.waffle.io/gondor/openstack4j/throughput.svg)](https://waffle.io/gondor/openstack4j/metrics)
+[![Throughput Graph](https://graphs.waffle.io/ContainX/openstack4j/throughput.svg)](https://waffle.io/ContainX/openstack4j/metrics)
 
 Quick Usage Guide
 -----------------

--- a/connectors/httpclient/pom.xml
+++ b/connectors/httpclient/pom.xml
@@ -7,7 +7,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-httpclient</artifactId>
 	<name>OpenStack4j HttpComponents-HttpClient Connector</name>
-	<url>http://github.com/gondor/openstack4j/</url>
+	<url>http://github.com/ContainX/openstack4j/</url>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/connectors/jersey2/pom.xml
+++ b/connectors/jersey2/pom.xml
@@ -7,7 +7,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-jersey2</artifactId>
 	<name>OpenStack4j Jersey2 Connector</name>
-	<url>http://github.com/gondor/openstack4j/</url>
+	<url>http://github.com/ContainX/openstack4j/</url>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/connectors/okhttp/pom.xml
+++ b/connectors/okhttp/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-okhttp</artifactId>
     <name>OpenStack4j OKHttp Connector</name>
-    <url>http://github.com/gondor/openstack4j/</url>
+    <url>http://github.com/ContainX/openstack4j/</url>
     <packaging>jar</packaging>
 
     <properties>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>openstack4j-connectors</artifactId>
     <name>OpenStack4j Connectors</name>
     <description>OpenStack Java API Connectors</description>
-    <url>http://github.com/gondor/openstack4j/</url>
+    <url>http://github.com/ContainX/openstack4j/</url>
     <packaging>pom</packaging>
 
     <modules>

--- a/connectors/resteasy/pom.xml
+++ b/connectors/resteasy/pom.xml
@@ -7,7 +7,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-resteasy</artifactId>
 	<name>OpenStack4j RestEasy Connector</name>
-	<url>http://github.com/gondor/openstack4j/</url>
+	<url>http://github.com/ContainX/openstack4j/</url>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -6,8 +6,8 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-core-integration-test</artifactId>
-	<name>OpenStack4j Integrationtest Cases</name>
-	<url>http://github.com/gondor/openstack4j/</url>
+	<name>OpenStack4j Integration test Cases</name>
+	<url>http://github.com/ContainX/openstack4j/</url>
 	<packaging>pom</packaging>
 	<properties>
 		<skipTests>false</skipTests>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -7,7 +7,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-core-test</artifactId>
 	<name>OpenStack4j Test Cases</name>
-	<url>http://github.com/gondor/openstack4j/</url>
+	<url>http://github.com/ContainX/openstack4j/</url>
 	<packaging>jar</packaging>
 	<properties>
 		<skipTests>true</skipTests>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
 	<artifactId>openstack4j-core</artifactId>
 	<name>OpenStack4j Core</name>
 	<description>OpenStack Java API</description>
-	<url>http://github.com/gondor/openstack4j/</url>
+	<url>http://github.com/ContainX/openstack4j/</url>
 	<packaging>jar</packaging>
 
 	<build>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -8,7 +8,7 @@
 	<artifactId>openstack4j</artifactId>
 	<name>OpenStack4j Distribution</name>
 	<description>OpenStack Java API</description>
-	<url>http://github.com/gondor/openstack4j/</url>
+	<url>http://github.com/ContainX/openstack4j/</url>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>3.0.3-SNAPSHOT</version>
     <name>OpenStack4j Parent</name>
     <description>OpenStack Java API</description>
-    <url>http://github.com/gondor/openstack4j/</url>
+    <url>http://github.com/ContainX/openstack4j/</url>
     <packaging>pom</packaging>
     <properties>
         <release.version>2.0.0</release.version>
@@ -35,9 +35,9 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git@github.com:gondor/openstack4j.git</connection>
-        <developerConnection>scm:git:git@github.com:gondor/openstack4j.git</developerConnection>
-        <url>http://github.com/gondor/openstack4j/</url>
+        <connection>scm:git:git@github.com:ContainX/openstack4j.git</connection>
+        <developerConnection>scm:git:git@github.com:ContainX/openstack4j.git</developerConnection>
+        <url>http://github.com/ContainX/openstack4j/</url>
         <tag>HEAD</tag>
     </scm>
     <mailingLists>


### PR DESCRIPTION
Fixes some URLs.
And the waffle graph will work again!

[![Throughput Graph](https://graphs.waffle.io/ContainX/openstack4j/throughput.svg)](https://waffle.io/ContainX/openstack4j/metrics)