### PR TITLE
Fix #857 - router_ids is missing from NeutronFirewall

### DIFF
--- a/core/src/main/java/org/openstack4j/model/network/ext/Firewall.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/Firewall.java
@@ -1,5 +1,7 @@
 package org.openstack4j.model.network.ext;
 
+import java.util.List;
+
 import org.openstack4j.common.Buildable;
 import org.openstack4j.model.ModelEntity;
 import org.openstack4j.model.network.ext.builder.FirewallBuilder;
@@ -66,4 +68,10 @@ public interface Firewall extends ModelEntity, Buildable<FirewallBuilder> {
 	 * 				This firewall will implement the rules contained in the firewall policy represented by this uuid.
 	 */
 	public String getPolicy();
+
+	/**
+	 * 
+	 * @return routerIds : A list of UUIDs for routers that are associated with the firewall.
+	 */
+	public List<String> getRouterIds();
 }

--- a/core/src/main/java/org/openstack4j/model/network/ext/builder/FirewallBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/builder/FirewallBuilder.java
@@ -1,5 +1,7 @@
 package org.openstack4j.model.network.ext.builder;
 
+import java.util.List;
+
 import org.openstack4j.common.Buildable.Builder;
 import org.openstack4j.model.network.ext.Firewall;
 
@@ -49,4 +51,10 @@ public interface FirewallBuilder extends Builder<FirewallBuilder, Firewall> {
 	 * @return FirewallBuilder
 	 */
 	public FirewallBuilder policy(String policyId);
+
+	/**
+	 * @param routerIds : A list of UUIDs for routers that are associated with the firewall.
+	 * @return FirewallBuilder
+	 */
+	public FirewallBuilder routerIds(List<String> routerIds);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronFirewall.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronFirewall.java
@@ -73,6 +73,9 @@ public class NeutronFirewall implements Firewall {
 	@JsonProperty("firewall_policy_id")
 	private String policyId;
 	
+	@JsonProperty("router_ids")
+	private List<String> routerIds;
+	
 	/**
 	 * Wrap this Firewall to a builder
 	 * @return FirewallBuilder
@@ -123,6 +126,11 @@ public class NeutronFirewall implements Firewall {
 	public FirewallStatus getStatus() {
 		return status;
 	}
+	
+	@Override
+	public List<String> getRouterIds() {
+		return routerIds;
+	}
 
 	@JsonIgnore
 	@Override
@@ -137,6 +145,7 @@ public class NeutronFirewall implements Firewall {
 				.add("status", status).add("policyId", policyId)
 				.add("shared", shared).add("adminStateUp", adminStateUp)
 				.add("tenantId", tenantId).add("description", description)
+				.add("routerIds", routerIds)
 				.toString();
 	}
 	
@@ -214,6 +223,12 @@ public class NeutronFirewall implements Firewall {
 		@Override
 		public FirewallBuilder policy(String policyId) {
 			f.policyId = policyId;
+			return this;
+		}
+		
+		@Override
+		public FirewallBuilder routerIds(List<String> routerIds) {
+			f.routerIds = routerIds;
 			return this;
 		}
 	}


### PR DESCRIPTION
This PR fixes #857.
It adds support for router_ids in the Firewall class.
This was introduced in Kilo with the following commit:
https://github.com/openstack/neutron-fwaas/commit/d0704f056021b235caba1f906b1733f422ce68c1