### PR TITLE
fix json mapping for subnetId

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaInterfaceAttachment.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaInterfaceAttachment.java
@@ -85,7 +85,7 @@ public class NovaInterfaceAttachment implements InterfaceAttachment {
 
         @JsonProperty("ip_address")
         private String ipAddress;
-        @JsonProperty("subnetId")
+        @JsonProperty("subnet_id")
         private String subnetId;
         
         


### PR DESCRIPTION
http://developer.openstack.org/api-ref-compute-v2.1.html

`"ip_address": "192.168.1.3",
  "**subnet_id**": "f8a6e8f8-c2ec-497c-9f23-da9616de54ef"`

class org.openstack4j.openstack.compute.domain.NovaInterfaceAttachment.NovaFixedIp
