### PR TITLE
Issue #890 - Enforce build requirement of Maven version 3.0+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,27 @@
                     <goals>deploy</goals>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0</version>
+                                    <message>Build FAILURE: Maven version 3.0+ REQUIRED!</message>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Added `maven-enforcer-plugin` to master `pom.xml` to require Maven version 3.0+ or fail build with message: `Build FAILURE: Maven version 3.0+ REQUIRED!`