### PR TITLE
Implement close method in the okhttp HttpResponseImpl to avoid leak

### DIFF
--- a/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpResponseImpl.java
+++ b/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpResponseImpl.java
@@ -128,6 +128,9 @@ public class HttpResponseImpl implements HttpResponse {
 
     @Override
     public void close() throws IOException {
+        if (response != null) {
+            response.body().close();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix #855 