### PR TITLE
support snapshot_id in volume backups

### DIFF
--- a/core-test/src/main/resources/storage/v1/volumebackup_from_snapshot.json
+++ b/core-test/src/main/resources/storage/v1/volumebackup_from_snapshot.json
@@ -1,0 +1,25 @@
+{
+  "backup": {
+    "status": "available",
+    "description": "by API999b49ff-a813-45cc-aef3-3ec82f089490",
+    "links": [{
+      "href": "https://192.168.100.3:8776/v1/aec84f30304745c1b568593eee763eb4/backups/735359d5-9584-4046-94d3-5ffc47be84f5",
+      "rel": "self"
+    }, {
+      "href": "https://192.168.100.3:8776/aec84f30304745c1b568593eee763eb4/backups/735359d5-9584-4046-94d3-5ffc47be84f5",
+      "rel": "bookmark"
+    }],
+    "availability_zone": "nova",
+    "has_dependent_backups": false,
+    "volume_id": "999b49ff-a813-45cc-aef3-3ec82f089490",
+    "fail_reason": null,
+    "id": "735359d5-9584-4046-94d3-5ffc47be84f5",
+    "size": 1,
+    "object_count": 22,
+    "container": "test999b49ff-a813-45cc-aef3-3ec82f089490",
+    "name": "backup999b49ff-a813-45cc-aef3-3ec82f089490",
+    "created_at": "2016-11-22T06:23:33.000000",
+    "is_incremental": false,
+    "snapshot_id": "b4b3258d-555a-4fce-8f53-69cc2ae96d3c"
+  }
+}

--- a/core/src/main/java/org/openstack4j/model/storage/block/VolumeBackup.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/VolumeBackup.java
@@ -105,4 +105,9 @@ public interface VolumeBackup   extends ModelEntity {
 	 */
 	Boolean hasDependent();
 
+	/**
+	 * @return If the backup was created from snapshot, the snapshot id. Otherwise, null.
+	 */
+	String getSnapshotId();
+
 }

--- a/core/src/main/java/org/openstack4j/model/storage/block/VolumeBackupCreate.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/VolumeBackupCreate.java
@@ -36,4 +36,15 @@ public interface VolumeBackupCreate extends ModelEntity, Buildable<VolumeBackupC
 	 */
 	boolean isIncremental();
 
+	/**
+	 * @return Force mode. True to do backup while a volume is attached. Default is false.
+	 */
+	boolean isForce();
+
+	/**
+	 * @return Force mode. True to do backup while a volume is attached. Default is false.
+	 */
+	String getSnapshotId();
+
+
 }

--- a/core/src/main/java/org/openstack4j/model/storage/block/builder/VolumeBackupCreateBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/builder/VolumeBackupCreateBuilder.java
@@ -16,4 +16,8 @@ public interface VolumeBackupCreateBuilder  extends Builder<VolumeBackupCreateBu
  
 	VolumeBackupCreateBuilder incremental(boolean  incremental);
 
+	VolumeBackupCreateBuilder force(boolean force);
+
+	VolumeBackupCreateBuilder snapshotId(String snapshotId);
+
 }

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeBackup.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeBackup.java
@@ -46,6 +46,10 @@ public class CinderVolumeBackup  implements  VolumeBackup{
 	@JsonProperty("is_incremental")
 	@Nullable
 	private Boolean incremental;
+
+	@JsonProperty("snapshot_id")
+	@Nullable
+	private String snapshotId;
 	
 	/**
 	 * {@inheritDoc}
@@ -143,12 +147,23 @@ public class CinderVolumeBackup  implements  VolumeBackup{
 		return objectCount;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public Boolean hasDependent() {
 		return hasDependent;
 	}
-	
-	
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getSnapshotId() {
+		return snapshotId;
+	}
+
+
 	public static class VolumeBackups extends ListResult<CinderVolumeBackup> {
 
 		private static final long serialVersionUID = 1L;

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeBackupCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeBackupCreate.java
@@ -17,6 +17,11 @@ public class CinderVolumeBackupCreate implements VolumeBackupCreate {
 	private String volumeId;
 	@JsonProperty("incremental")
 	private boolean incremental;
+	@JsonProperty("force")
+	private boolean force;
+	@JsonProperty("snapshot_id")
+	private String snapshotId;
+
 
 	/**
 	 * {@inheritDoc}
@@ -48,6 +53,22 @@ public class CinderVolumeBackupCreate implements VolumeBackupCreate {
 	@Override
 	public boolean isIncremental() {
 		return incremental;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isForce() {
+		return force;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getSnapshotId() {
+		return snapshotId;
 	}
 
 	/**
@@ -117,6 +138,18 @@ public class CinderVolumeBackupCreate implements VolumeBackupCreate {
 		@Override
 		public VolumeBackupCreateBuilder incremental(boolean incremental) {
 			model.incremental = incremental;
+			return this;
+		}
+
+		@Override
+		public VolumeBackupCreateBuilder force(boolean force) {
+			model.force = force;
+			return this;
+		}
+
+		@Override
+		public VolumeBackupCreateBuilder snapshotId(String snapshotId) {
+			model.snapshotId = snapshotId;
 			return this;
 		}
 	}


### PR DESCRIPTION
Create a volume backup from a snapshot.
This feature is not documented in 
http://developer.openstack.org/api-ref/block-storage/v3/?expanded=create-a-backup-detail
but it is indeed supported by the Openstack server and the CLI

https://github.com/ContainX/openstack4j/issues/874

