### PR TITLE
add Evacuate Server (evacuate Action)

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
@@ -70,8 +70,8 @@ public class ServerTests extends AbstractTest {
     public void evacuateServer() throws Exception {
         respondWith(JSON_SERVER_EVACUATE);
         
-        ServerPassword password =  osv3().compute().servers().evacuate("e565cbdb-8e74-4044-ba6e-0155500b2c46", EvacuateOptions.create().host("server-test-1").onSharedStorage(false));
-        assertNotNull(password.getPassword());        
+        ServerPassword password =  osv3().compute().servers().evacuate("e565cbdb-8e74-4044-ba6e-0155500b2c46", EvacuateOptions.create().host("server-test-1").onSharedStorage(false));          
+        assertEquals(password.getPassword(), "MySecretPass");        
     }
 
 }

--- a/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
@@ -25,6 +25,7 @@ public class ServerTests extends AbstractTest {
 
     private static final String JSON_SERVERS = "/compute/servers.json";
     private static final String JSON_SERVER_CREATE = "/compute/server_create.json";
+    private static final String JSON_SERVER_EVACUATE = "/compute/server_evacuate.json";
 
     @Test
     public void listServer() throws Exception {
@@ -67,7 +68,7 @@ public class ServerTests extends AbstractTest {
     
     @Test
     public void evacuateServer() throws Exception {
-        respondWith(JSON_SERVER_CREATE);
+        respondWith(JSON_SERVER_EVACUATE);
         
         ServerPassword password =  osv3().compute().servers().evacuate("e565cbdb-8e74-4044-ba6e-0155500b2c46", EvacuateOptions.create().host("server-test-1").onSharedStorage(false));
         assertNotNull(password.getPassword());        

--- a/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
@@ -1,5 +1,6 @@
 package org.openstack4j.api.compute;
 
+import static org.junit.Assert.assertNotNull;
 import static org.testng.Assert.assertEquals;
 
 import java.util.List;
@@ -8,7 +9,9 @@ import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.exceptions.ServerResponseException;
 import org.openstack4j.model.compute.Server;
+import org.openstack4j.model.compute.ServerPassword;
 import org.openstack4j.model.compute.Server.Status;
+import org.openstack4j.model.compute.actions.EvacuateOptions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -60,6 +63,14 @@ public class ServerTests extends AbstractTest {
     @Override
     protected Service service() {
         return Service.COMPUTE;
+    }
+    
+    @Test
+    public void evacuateServer() throws Exception {
+        respondWith(JSON_SERVER_CREATE);
+        
+        ServerPassword password =  osv3().compute().servers().evacuate("e565cbdb-8e74-4044-ba6e-0155500b2c46", EvacuateOptions.create().host("server-test-1").onSharedStorage(false));
+        assertNotNull(password.getPassword());        
     }
 
 }

--- a/core-test/src/main/resources/compute/server_evacuate.json
+++ b/core-test/src/main/resources/compute/server_evacuate.json
@@ -1,0 +1,3 @@
+{
+    "adminPass": "MySecretPass"
+}

--- a/core/src/main/java/org/openstack4j/api/compute/ServerService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ServerService.java
@@ -18,6 +18,7 @@ import org.openstack4j.model.compute.VNCConsole;
 import org.openstack4j.model.compute.VNCConsole.Type;
 import org.openstack4j.model.compute.VolumeAttachment;
 import org.openstack4j.model.compute.actions.BackupOptions;
+import org.openstack4j.model.compute.actions.EvacuateOptions;
 import org.openstack4j.model.compute.actions.LiveMigrateOptions;
 import org.openstack4j.model.compute.actions.RebuildOptions;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
@@ -340,4 +341,13 @@ public interface ServerService {
      * @return the encrypted server password
      */
     ServerPassword getPassword(String serverId);
+
+    /**
+     * Evacuates a server identified with {@code serverId} from a failed host to a new host
+     * 
+     * @param serverId the server identifier
+     * @param options evaucate options
+     * @return ActionResponse
+     */
+    ServerPassword evacuate(String serverId, EvacuateOptions options);
 }

--- a/core/src/main/java/org/openstack4j/model/compute/actions/EvacuateOptions.java
+++ b/core/src/main/java/org/openstack4j/model/compute/actions/EvacuateOptions.java
@@ -1,0 +1,76 @@
+package org.openstack4j.model.compute.actions;
+
+/**
+ * Options to evacuates a server from a failed host to a new host
+ * 
+ */
+public class EvacuateOptions extends BaseActionOptions {
+    
+    private enum Option implements OptionEnum {
+        HOST("host"),        
+        ADMIN_PASS("adminPass"),
+        ON_SHARED_STORAGE("onSharedStorage");
+        private final String param;
+        private Option(String param) { this.param = param; }
+        
+        public String getParam() {
+            return param;
+        }
+    }
+
+    private EvacuateOptions() {
+    	super();   
+    	add(Option.HOST, null);
+        add(Option.ADMIN_PASS, null);
+        add(Option.ON_SHARED_STORAGE, false);            
+    }
+    
+    public static EvacuateOptions create() {
+        return new EvacuateOptions();
+    }
+    
+    /**
+     * Name of the the host (Optional)
+     * 
+     * @param name or ID of the host to which the server is evacuated
+     * @return EvacuateOptions
+     */
+    public EvacuateOptions host(String host) {
+        add(Option.HOST, host);
+        return this;
+    }
+    
+    /**
+     * An administrative password (Optional)
+     * 
+     * @param adminPass to access the evacuated or rebuilt instance
+     * @return EvacuateOptions
+     */
+    public EvacuateOptions adminPass(String adminPass) {
+        add(Option.ADMIN_PASS, adminPass);
+        return this;
+    }
+    
+    /**
+     * Server on shared storage
+     * 
+     * @param isShare if isShare, server on shared storage
+     * @return EvacuateOptions
+     */
+    public EvacuateOptions onSharedStorage(boolean isShare) {
+        add(Option.ON_SHARED_STORAGE, isShare);
+        return this;
+    }
+    
+    public String getHost() {
+        return get(Option.HOST);
+    }
+    
+    public String getAdminPass() {
+        return get(Option.ADMIN_PASS);
+    }
+    
+    public boolean isOnSharedStorage() {
+        return get(Option.ON_SHARED_STORAGE);
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/AdminPass.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/AdminPass.java
@@ -1,0 +1,27 @@
+package org.openstack4j.openstack.compute.domain;
+
+import org.openstack4j.model.compute.ServerPassword;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+/**
+ * Administrative password
+ * 
+ * @author taemin
+ *
+ */
+public class AdminPass implements ServerPassword {
+
+    private static final long serialVersionUID = 1L;
+    @JsonProperty
+    private String adminPass;
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPassword() {
+        return adminPass;
+    }
+    
+    
+}

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/EvacuateAction.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/EvacuateAction.java
@@ -1,0 +1,54 @@
+package org.openstack4j.openstack.compute.domain.actions;
+
+import org.openstack4j.model.compute.actions.EvacuateOptions;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+/**
+ * Evacuate for a server from a failed host to a new host
+ *  
+ */
+@JsonRootName("evacuate")
+public class EvacuateAction implements ServerAction {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("host")
+    private String host;
+    
+    @JsonProperty("adminPass")
+    private String adminPass;
+    
+    @JsonProperty("onSharedStorage")
+    private boolean onSharedStorage;
+    
+    public static EvacuateAction create(EvacuateOptions options) {
+    	EvacuateAction action = new EvacuateAction();
+        action.host = options.getHost();
+        action.adminPass = options.getAdminPass();
+        action.onSharedStorage = options.isOnSharedStorage();
+        return action;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    @JsonIgnore
+    public String getAdminPass() {
+        return adminPass;
+    }
+
+    @JsonIgnore
+    public boolean isOnSharedStorage() {
+        return onSharedStorage;
+    }
+    
+    @Override
+    public String toString() {
+        return "evacuate";
+    }
+    
+}

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
@@ -26,10 +26,12 @@ import org.openstack4j.model.compute.VNCConsole;
 import org.openstack4j.model.compute.VNCConsole.Type;
 import org.openstack4j.model.compute.VolumeAttachment;
 import org.openstack4j.model.compute.actions.BackupOptions;
+import org.openstack4j.model.compute.actions.EvacuateOptions;
 import org.openstack4j.model.compute.actions.LiveMigrateOptions;
 import org.openstack4j.model.compute.actions.RebuildOptions;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
 import org.openstack4j.openstack.common.Metadata;
+import org.openstack4j.openstack.compute.domain.AdminPass;
 import org.openstack4j.openstack.compute.domain.ConsoleOutput;
 import org.openstack4j.openstack.compute.domain.NovaPassword;
 import org.openstack4j.openstack.compute.domain.NovaServer;
@@ -47,6 +49,7 @@ import org.openstack4j.openstack.compute.domain.actions.BasicActions.Reboot;
 import org.openstack4j.openstack.compute.domain.actions.BasicActions.Resize;
 import org.openstack4j.openstack.compute.domain.actions.BasicActions.RevertResize;
 import org.openstack4j.openstack.compute.domain.actions.CreateSnapshotAction;
+import org.openstack4j.openstack.compute.domain.actions.EvacuateAction;
 import org.openstack4j.openstack.compute.domain.actions.LiveMigrationAction;
 import org.openstack4j.openstack.compute.domain.actions.RebuildAction;
 import org.openstack4j.openstack.compute.domain.actions.ResetStateAction;
@@ -454,4 +457,16 @@ public class ServerServiceImpl extends BaseComputeServices implements ServerServ
         checkNotNull(serverId);
         return get(NovaPassword.class, uri("/servers/%s/os-server-password", serverId)).execute();
     }   
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ServerPassword evacuate(String serverId, EvacuateOptions options) {
+        checkNotNull(serverId);
+      
+        return post(AdminPass.class, uri("/servers/%s/action", serverId))
+                    .entity(EvacuateAction.create(options))
+                    .execute();            
+    }
 }


### PR DESCRIPTION
Hi, I'm taemin
I added Evacuate Server.
I did tests about this api and checked the result.

The example below.
ServerPassword password =
os.compute().servers().evacuate("1427b0a6-e6a1-496",
EvacuateOptions.create().host("compute1").onSharedStorage(false));	
		System.out.println(password.getPassword());

I hope you review codes I pulled. 