### PR TITLE
Issue 944: etag support in os.objectStorage().objects().get()

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/storage/ObjectStorageTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/ObjectStorageTests.java
@@ -1,6 +1,9 @@
 package org.openstack4j.api.storage;
 
 import static org.openstack4j.model.storage.object.SwiftHeaders.CONTAINER_METADATA_PREFIX;
+import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_LENGTH;
+import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_TYPE;
+import static org.openstack4j.model.storage.object.SwiftHeaders.ETAG;
 import static org.testng.Assert.*;
 
 import java.util.List;
@@ -8,6 +11,7 @@ import java.util.Map;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.model.storage.object.SwiftContainer;
+import org.openstack4j.model.storage.object.SwiftObject;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Maps;
@@ -48,5 +52,20 @@ public class ObjectStorageTests extends AbstractTest {
         metadata.put(CONTAINER_METADATA_PREFIX+NAME_BOOK, "TestBook");
         metadata.put(CONTAINER_METADATA_PREFIX+NAME_YEAR, "2000");
         return metadata;
+    }
+
+    public void objectRetrievalTest() throws Exception {
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put(CONTENT_LENGTH, "15");
+        headers.put(CONTENT_TYPE, "application/json");
+        headers.put(ETAG, "12345678901234567890");
+        respondWith(headers, 200, "[\"hello world\"]");
+
+        SwiftObject object = osv3().objectStorage().objects().get("test-container", "test-file");
+        assertEquals(object.getContainerName(), "test-container");
+        assertEquals(object.getName(), "test-file");
+        assertEquals(object.getSizeInBytes(), 15);
+        assertEquals(object.getMimeType(), "application/json");
+        assertEquals(object.getETag(), "12345678901234567890");
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
@@ -2,6 +2,7 @@ package org.openstack4j.openstack.storage.object.functions;
 
 import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_LENGTH;
 import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_TYPE;
+import static org.openstack4j.model.storage.object.SwiftHeaders.ETAG;
 import static org.openstack4j.model.storage.object.SwiftHeaders.LAST_MODIFIED;
 import static org.openstack4j.openstack.internal.Parser.asLong;
 
@@ -38,11 +39,10 @@ public class ParseObjectFunction implements Function<HttpResponse, SwiftObject> 
                   .containerName(location.getContainerName())
                   .mimeType(resp.header(CONTENT_TYPE))
                   .sizeBytes(asLong(resp.header(CONTENT_LENGTH)))
+                  .eTag(resp.header(ETAG))
                   .metadata(MapWithoutMetaPrefixFunction.INSTANCE.apply(resp.headers()))
                   .lastModified(Parser.toRFC822DateParse(resp.header(LAST_MODIFIED)))
                   .build();
     }
-    
-    
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
@@ -44,5 +44,6 @@ public class ParseObjectFunction implements Function<HttpResponse, SwiftObject> 
                   .lastModified(Parser.toRFC822DateParse(resp.header(LAST_MODIFIED)))
                   .build();
     }
+    
 
 }


### PR DESCRIPTION
This PR resolves issue #944  by modifying ParseObjectFunction such that we now get the eTag for objects retrieved from swift.  Also added a unit test.