### PR TITLE
issue 957: run as non-root user in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,10 @@ FROM maven:latest
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app
+
+RUN useradd -m -u 1000 builder
+RUN chown -R builder /usr/src/app
+USER builder
+
 RUN mvn clean compile
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 IMAGE_NAME := openstack4j-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
-DOCKER_RUN := docker run --rm -it --privileged $(IMAGE_NAME)
+DOCKER_RUN := docker run --rm -it --privileged -e MAVEN_CONFIG=/home/builder/.m2 $(IMAGE_NAME)
 
 default: build
 


### PR DESCRIPTION
This PR resolves Issue #957 in which one of the unit tests fails because it has root privileges in docker.  With this patch maven runs in docker as a non-root user named "builder" instead.

