### PR TITLE
Extended OS4J to support OpenStack Magnum Service APIs

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/AbstractTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/AbstractTest.java
@@ -35,6 +35,7 @@ public abstract class AbstractTest {
         SHARE(8786), 
         OBJECT_STORAGE(8800),
         BARBICAN(9311),
+        MAGNUM(9511),
         ORCHESTRATION(8004),
         DATABASE(8779),
     	TACKER(9890),

--- a/core-test/src/main/java/org/openstack4j/api/magnum/MagnumTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/magnum/MagnumTests.java
@@ -1,0 +1,72 @@
+package org.openstack4j.api.magnum;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.Builders;
+import org.openstack4j.model.magnum.Baymodel;
+import org.openstack4j.model.magnum.Mservice;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test cases for Magnum Services
+ * 
+ * @author Sohan Sangwan
+ */
+@Test(suiteName = "magnum")
+public class MagnumTests extends AbstractTest {
+    private static final String JSON_MSERVICES = "/magnum/mservices.json";
+    private static final String JSON_BAYMODEL_GETALL_RESPONSE = "/magnum/baymodel_get_all_resp.json";
+    private static final String JSON_BAYMODEL_CRUD_RESPONSE = "/magnum/baymodel_create_resp.json";
+    
+    @Test
+    public void magnum_mservice_list_test() throws IOException {
+        respondWith(JSON_MSERVICES);
+        List<? extends Mservice> resp = osv3().magnum().listMservices();
+        assertEquals(resp.size(), 1);
+    }
+    
+    @Test
+    public void magnum_baymodel_list() throws IOException {
+        respondWith(JSON_BAYMODEL_GETALL_RESPONSE);
+        List<? extends Baymodel> resp = osv3().magnum().listBaymodels();
+        assertEquals(resp.size(), 1);
+    } 
+    @Test
+    public void magnum_baymodel_crud_test() throws IOException {
+        
+       
+        Baymodel baymodel = Builders.baymodel()
+                .name("k8s-bm2")
+                .keypairId("magnum")
+                .publicBaymodel(false)
+                .dockerVolumeSize("3")
+                .serverType("vm")
+                .externalNetworkId("public")
+                .imageId("fedora-atomic-latest")
+                .volumeDriver("cinder")
+                .registryEnabled(false)
+                .coe("kubernetes")
+                .flavorId("m1.small")
+                .dnsNameserver("8.8.8.8")
+                .uuid("085e1c4d-4f68-4bfd-8462-74b9e14e4f39")
+                .build();
+        
+        //Create a baymodel
+        respondWith(JSON_BAYMODEL_CRUD_RESPONSE);
+        Baymodel resp = osv3().magnum().createBaymodel(baymodel);
+        assertEquals(resp.getName(), baymodel.getName());        
+ 
+    }
+    
+    
+
+    @Override
+    protected Service service() {
+        return Service.MAGNUM;
+    }
+}

--- a/core-test/src/main/resources/identity/v3/authv3_project.json
+++ b/core-test/src/main/resources/identity/v3/authv3_project.json
@@ -406,6 +406,31 @@
 				"id": "1236500210a24c38a3702b6825e56789",
 				"name": "murano"
 			}, {
+				"endpoints": [
+					{
+						"region_id": "RegionOne",
+						"url": "http://127.0.0.1:9511/v1",
+						"region": "RegionOne",
+						"interface": "public",
+						"id": "123458912d3f49a09df51035681d5991"
+					}, {
+						"region_id": "RegionOne",
+						"url": "http://127.0.0.1:9511/v1",
+						"region": "RegionOne",
+						"interface": "admin",
+						"id": "123458912d3f49a09df51035681d5992"
+					}, {
+						"region_id": "RegionOne",
+						"url": "http://127.0.0.1:9511/v1",
+						"region": "RegionOne",
+						"interface": "internal",
+						"id": "123458912d3f49a09df51035681d5993"
+					}
+				],
+				"type": "container",
+				"id": "3afa96cf8ff44b03a5f93ec3b1d361c0",
+				"name": "magnum"
+			}, {
 			"endpoints": [
 			  {
 				"region_id": "RegionOne",

--- a/core-test/src/main/resources/magnum/baymodel_create_resp.json
+++ b/core-test/src/main/resources/magnum/baymodel_create_resp.json
@@ -1,0 +1,44 @@
+{  
+   "insecure_registry":null,
+   "links":[
+      {
+         "href":"http://127.0.0.1:9511/v1/baymodels/085e1c4d-4f68-4bfd-8462-74b9e14e4f39",
+         "rel":"self"
+      },
+      {
+         "href":"http://1127.0.0.1:9511/baymodels/085e1c4d-4f68-4bfd-8462-74b9e14e4f39",
+         "rel":"bookmark"
+      }
+   ],
+   "http_proxy":"http://10.164.177.169:8080",
+   "updated_at":null,
+   "floating_ip_enabled":true,
+   "fixed_subnet":null,
+   "master_flavor_id":null,
+   "uuid":"085e1c4d-4f68-4bfd-8462-74b9e14e4f39",
+   "no_proxy":"10.0.0.0/8,172.0.0.0/8,192.0.0.0/8,localhost",
+   "https_proxy":"http://10.164.177.169:8080",
+   "tls_disabled":false,
+   "keypair_id":"kp",
+   "public":false,
+   "labels":{
+
+   },
+   "docker_volume_size":3,
+   "server_type":"vm",
+   "external_network_id":"public",
+   "cluster_distro":"fedora-atomic",
+   "image_id":"fedora-atomic-latest",
+   "volume_driver":"cinder",
+   "registry_enabled":false,
+   "docker_storage_driver":"devicemapper",
+   "apiserver_port":null,
+   "name":"k8s-bm2",
+   "created_at":"2016-08-29T02:08:08+00:00",
+   "network_driver":"flannel",
+   "fixed_network":null,
+   "coe":"kubernetes",
+   "flavor_id":"m1.small",
+   "master_lb_enabled":true,
+   "dns_nameserver":"8.8.8.8"
+}

--- a/core-test/src/main/resources/magnum/baymodel_get_all_resp.json
+++ b/core-test/src/main/resources/magnum/baymodel_get_all_resp.json
@@ -1,0 +1,53 @@
+{
+    "links": {
+        "self": "http://127.0.0.1:9511/v1/baymodels",
+        "previous": null,
+        "next": null
+    },
+    "baymodels": [
+        {
+            "insecure_registry": null,
+            "links": [
+                {
+                    "href": "http://10.164.180.104:9511/v1/baymodels/085e1c4d-4f68-4bfd-8462-74b9e14e4f39",
+                    "rel": "self"
+                },
+                {
+                    "href": "http://10.164.180.104:9511/baymodels/085e1c4d-4f68-4bfd-8462-74b9e14e4f39",
+                    "rel": "bookmark"
+                }
+            ],
+            "http_proxy": "http://10.164.177.169:8080",
+            "updated_at": null,
+            "floating_ip_enabled": true,
+            "fixed_subnet": null,
+            "master_flavor_id": null,
+            "uuid": "085e1c4d-4f68-4bfd-8462-74b9e14e4f39",
+            "no_proxy": "10.0.0.0/8,172.0.0.0/8,192.0.0.0/8,localhost",
+            "https_proxy": "http://10.164.177.169:8080",
+            "tls_disabled": false,
+            "keypair_id": "kp",
+            "public": false,
+            "labels": {
+                
+            },
+            "docker_volume_size": 3,
+            "server_type": "vm",
+            "external_network_id": "public",
+            "cluster_distro": "fedora-atomic",
+            "image_id": "fedora-atomic-latest",
+            "volume_driver": "cinder",
+            "registry_enabled": false,
+            "docker_storage_driver": "devicemapper",
+            "apiserver_port": null,
+            "name": "k8s-bm2",
+            "created_at": "2016-08-29T02:08:08+00:00",
+            "network_driver": "flannel",
+            "fixed_network": null,
+            "coe": "kubernetes",
+            "flavor_id": "m1.small",
+            "master_lb_enabled": true,
+            "dns_nameserver": "8.8.8.8"
+        }
+    ]
+}

--- a/core-test/src/main/resources/magnum/mservices.json
+++ b/core-test/src/main/resources/magnum/mservices.json
@@ -1,0 +1,19 @@
+{
+  "links": {
+    "self": "http://127.0.0.1:9511/v1/mservices",
+    "previous": null,
+    "next": null
+  },
+  "mservices": [  
+   {  
+      "id":"1",
+      "binary":"magnum-conductor",
+      "state":"up",
+      "host":"harsh-OptiPlex-7040",
+      "created_at":"2017-02-03T07:03:27+00:00",
+      "report_count":1903,
+      "updated_at":"2017-02-07T05:41:24+00:00",
+      "disabled_reason":null
+   }
+  ]
+}

--- a/core/src/main/java/org/openstack4j/api/Apis.java
+++ b/core/src/main/java/org/openstack4j/api/Apis.java
@@ -6,6 +6,7 @@ import org.openstack4j.api.compute.ComputeService;
 import org.openstack4j.api.gbp.GbpService;
 import org.openstack4j.api.heat.HeatService;
 import org.openstack4j.api.image.ImageService;
+import org.openstack4j.api.magnum.MagnumService;
 import org.openstack4j.api.manila.ShareService;
 import org.openstack4j.api.murano.v1.AppCatalogService;
 import org.openstack4j.api.networking.NetworkingService;
@@ -168,6 +169,15 @@ public class Apis {
 	public static SenlinService getSenlinServices() {
 		return get(SenlinService.class);
 	}
+
+	/**
+     * Gets the Magnum services API
+     *
+     * @return the Magnum Service
+     */
+    public static MagnumService getMagnumService() {
+        return get(MagnumService.class);
+    }
 
 
     /**

--- a/core/src/main/java/org/openstack4j/api/Builders.java
+++ b/core/src/main/java/org/openstack4j/api/Builders.java
@@ -28,6 +28,7 @@ import org.openstack4j.model.identity.v3.builder.*;
 import org.openstack4j.model.image.builder.ImageBuilder;
 import org.openstack4j.model.image.v2.builder.ImageUpdateBuilder;
 import org.openstack4j.model.image.v2.builder.TaskBuilder;
+import org.openstack4j.model.magnum.BaymodelBuilder;
 import org.openstack4j.model.manila.builder.*;
 import org.openstack4j.model.murano.v1.builder.EnvironmentBuilder;
 import org.openstack4j.model.murano.v1.builder.AppCatalogBuilders;
@@ -76,6 +77,7 @@ import org.openstack4j.openstack.identity.v3.domain.*;
 import org.openstack4j.openstack.image.domain.GlanceImage;
 import org.openstack4j.openstack.image.v2.domain.GlanceImageUpdate;
 import org.openstack4j.openstack.image.v2.domain.GlanceTask;
+import org.openstack4j.openstack.magnum.MagnumBaymodel;
 import org.openstack4j.openstack.manila.builder.ManilaBuilders;
 import org.openstack4j.openstack.manila.domain.*;
 import org.openstack4j.openstack.murano.v1.builder.MuranoBuilders;
@@ -1073,6 +1075,15 @@ public class Builders {
      */
     public static LoadBalancerV2UpdateBuilder loadBalancerV2Update() {
         return NeutronLoadBalancerV2Update.builder();
+    }
+
+    /**
+     * Magnum builder
+     * @return the magnum builder
+     */
+    
+    public static BaymodelBuilder baymodel() {
+        return MagnumBaymodel.builder();
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/api/OSClient.java
+++ b/core/src/main/java/org/openstack4j/api/OSClient.java
@@ -21,6 +21,7 @@ import org.openstack4j.api.types.Facing;
 import org.openstack4j.api.types.ServiceType;
 import org.openstack4j.model.identity.v2.Access;
 import org.openstack4j.model.identity.v3.Token;
+import org.openstack4j.api.magnum.MagnumService;
 
 import java.util.Set;
 
@@ -235,6 +236,13 @@ public interface OSClient< T extends OSClient<T>> {
      */
     SaharaService sahara();
     
+    /**
+     * Returns the Magnum Service API
+     * 
+     * @return the Magnum Service
+     */
+    MagnumService magnum();
+
     /**
      * OpenStack4j Client which authenticates against version V2
      */

--- a/core/src/main/java/org/openstack4j/api/magnum/MagnumService.java
+++ b/core/src/main/java/org/openstack4j/api/magnum/MagnumService.java
@@ -1,0 +1,354 @@
+package org.openstack4j.api.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.magnum.Bay;
+import org.openstack4j.model.magnum.Baymodel;
+import org.openstack4j.model.magnum.Carequest;
+import org.openstack4j.model.magnum.Certificate;
+import org.openstack4j.model.magnum.Cluster;
+import org.openstack4j.model.magnum.Clustertemplate;
+import org.openstack4j.model.magnum.Container;
+import org.openstack4j.model.magnum.Mservice;
+import org.openstack4j.model.magnum.Pod;
+
+
+/**
+ * OpenStack Container Infrastructure Management service (Magnum) APIs
+ * 
+ * @author Sohan Sangwan
+ *
+ */
+public interface MagnumService extends RestService {
+    /**
+     * Lists all Magnum Services: container infrastructure service status
+     * details
+     * 
+     * @return list of Magnum Services
+     */
+    List<? extends Mservice> listMservices();
+
+    /**
+     * Lists all Baymodels
+     * 
+     * @return list of Baymodels
+     */
+    List<? extends Baymodel> listBaymodels();
+
+    /**
+     * Creates a new baymodel
+     * 
+     * @param baymodel
+     * @return
+     */
+    Baymodel createBaymodel(Baymodel baymodel);
+
+    /**
+     * Deletes a baymodel
+     * 
+     * @param id
+     * @return
+     */
+    ActionResponse deleteBaymodel(String id);
+
+    /**
+     * Gets all information of a baymodel
+     * 
+     * @param id
+     * 
+     * @return baymodel information
+     */
+    Baymodel showBaymodel(String id);
+
+    /**
+     * Updates baymodel attributes
+     * 
+     * @param id
+     * @param operations
+     * 
+     * @return updated baymodel
+     */
+    Baymodel updateBaymodel(String id, String operations);
+
+    /**
+     * Lists all Bays/clusters
+     * 
+     * @return list of Bays
+     */
+    List<? extends Bay> listBays();
+
+    /**
+     * Creates a new bay
+     * 
+     * @param bay
+     * @return newly created bay
+     */
+    Bay createBay(Bay bay);
+
+    /**
+     * Deletes a bay
+     * 
+     * @param id
+     * @return
+     */
+    ActionResponse deleteBay(String id);
+    
+    /**
+     * Show a bay
+     * 
+     * @param id
+     * @return bay 
+     */
+    Bay showBay(String id);
+    
+    /**
+     * Update bay
+     * 
+     * @param id
+     * @param operations
+     * @return
+     */
+    Bay updateBay(String id, String operations);
+
+    // Containers
+    /**
+     * Lists all Containers
+     * 
+     * @return list of Containers
+     */
+    List<? extends Container> listContainers();
+
+    /**
+     * Creates a new Container
+     * 
+     * @param baymodel
+     * @return newly created Container
+     */
+    Container createContainer(Container container);
+
+    /**
+     * Deletes a Container
+     * 
+     * @param id
+     * @return success/failure response
+     */
+    ActionResponse deleteContainer(String uuid);
+
+    /**
+     * Execute command in a Container
+     * 
+     * @param id
+     * @param cmd
+     * @return output of the command
+     */
+    String execCmdInContainer(String id, String cmd);
+
+    /**
+     * Get logs of a Container
+     * 
+     * @param id
+     * @return logs
+     */
+    String getContainerLogs(String id);
+
+    /**
+     * Pause a Container
+     * 
+     * @param id
+     * @return paused Container
+     */
+    Container pauseContainer(String id);
+
+    /**
+     * Unpause a Container
+     * 
+     * @param id
+     * @return paused Container
+     */
+    Container unpauseContainer(String id);
+
+    /**
+     * Reboot a Container
+     * 
+     * @param id
+     * @return rebooted Container
+     */
+    Container rebootContainer(String id);
+
+    /**
+     * Start a Container
+     * 
+     * @param id
+     * @return Container
+     */
+    Container startContainer(String id);
+
+    /**
+     * Stop a Container
+     * 
+     * @param id
+     * @return Container
+     */
+    Container stopContainer(String id);
+    
+    /**
+     * Show a Container
+     * 
+     * @param id
+     * @return Container
+     */
+    Container showContainer(String id);
+    
+    /**
+     * Gets certificate
+     * 
+     * @param uuid of a bay or cluster
+     * @return certificate
+     */
+    Certificate getCertificate(String uuid);
+    
+    /**
+     * Generates certificate
+     * 
+     * @param  ca request
+     * @return certificate
+     */
+    Certificate signCertificate(Carequest ca);
+    
+    /**
+     * Rotate the CA certificate for a bay/cluster and 
+     * invalidate all user certificates.
+     * 
+     * @param uuid of a bay or cluster
+     * @return status
+     */
+    ActionResponse rotateCertificate(String uuid);
+    
+    //New clusters APIs
+    
+    /**
+     * Create new cluster based on cluster template
+     * 
+     * @param cluster
+     * @return
+     */
+    Cluster createCluster(Cluster cluster);
+    
+    /**
+     * List all clusters
+     * 
+     * @return
+     */
+    List<? extends Cluster> listClusters();
+    
+    /**
+     * Get all information of a cluster in Magnum
+     * 
+     * @param id of the cluster
+     * @return cluster
+     */
+    Cluster showCluster(String id);
+    
+    /**
+     * Delete a cluster.
+     * 
+     * @param id of the cluster
+     * @return success status
+     */
+    ActionResponse deleteCluster(String id);
+    
+    /**
+     * Update information of one cluster attributes using operations
+     * including: ``add``, ``replace`` or ``remove``. 
+     * The attributes to ``add`` and
+     * ``replace`` in the form of ``key=value`` while ``remove`` only needs the keys.
+     * 
+     * @param id
+     * @param operations
+     * @return updated cluster
+     */
+    Cluster updateCluster(String id, String operations);
+    
+    //Cluster templates
+    /**
+     * Create new cluster template
+     * @param template
+     * @return newly created cluster template
+     */
+    Clustertemplate createClustertemplate(Clustertemplate template);
+    
+    /**
+     * List all cluster templates
+     * 
+     * @return list of cluster templates
+     */
+    List<? extends Clustertemplate> listClustertemplate();
+    
+    /**
+     * Delete a cluster template
+     * 
+     * @param id of the clustertemplate 
+     * @return status
+     */
+    ActionResponse deleteClustertemplate(String id);
+    
+    /**
+     * Update information of one cluster template attributes using operations
+     * including: ``add``, ``replace`` or ``remove``. The attributes to ``add`` and
+     * ``replace`` in the form of ``key=value`` while ``remove`` only needs the keys.
+     * 
+     * @param cluster template
+     * 
+     * @return updated clustser template
+     */
+    Clustertemplate updateClustertemplate(String id, String operations);
+    
+    // Pod (group of containers) APIs
+    
+    /**
+     * List all pods
+     * 
+     * @return list of pods
+     */
+    List<? extends Pod> listPods(String bayUuid);
+    
+    /**
+     * Create a pod
+     * 
+     * @param pod
+     * @return pod
+     */
+    Pod createPod(Pod pod);
+    
+    /**
+     * Delete a pod
+     * 
+     * @param bayUuid
+     * @param id
+     * @return status
+     */
+    ActionResponse deletePod(String bayUuid, String id);
+    
+    /**
+     * Show a pod
+     * 
+     * @param bayUuid
+     * @param id
+     * @return pod
+     */
+    Pod showPod(String bayUuid, String id);
+    
+    /**
+     * Update a pod
+     * 
+     * @param bayUuid
+     * @param id
+     * @return pod
+     */
+    Pod updatePod(String bayUuid, String id, String operations);
+    
+    
+
+}

--- a/core/src/main/java/org/openstack4j/api/types/ServiceType.java
+++ b/core/src/main/java/org/openstack4j/api/types/ServiceType.java
@@ -20,6 +20,7 @@ public enum ServiceType {
 	BARBICAN("barbican", "key-manager"),
 	TACKER("tacker", "nfv-orchestration"),
 	ARTIFACT("glare", "artifact"),
+    MAGNUM("magnum", "container"),
 	UNKNOWN("NA", "NA")
 	;
 

--- a/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
+++ b/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
@@ -49,5 +49,18 @@ public final class ClientConstants {
     public static final String PATH_SERVICE_CATALOGS = "auth/catalog";
     public static final String PATH_TENANTS = "/tenants";
     public static final String PATH_ARTIFACTS = "/artifacts";
+	
+	//Magnum APIs
+    // list all Magnum Services
+    public static final String MAGNUM_MSERVICES = "/mservices";
+    // list baymodels
+    public static final String MAGNUM_BAYMODELS = "/baymodels";
+    // bays
+    public static final String MAGNUM_BAYS = "/bays";
+    public static final String MAGNUM_CONTAINERS = "/containers";
+    public static final String MAGNUM_CERTIFICATES = "/certificates";
+    public static final String MAGNUM_CLUSTERS = "/clusters";
+    public static final String MAGNUM_CLUSTERTEMPLATES = "/clustertemplates";
+    public static final String MAGNUM_PODS = "/pods";
 
 }

--- a/core/src/main/java/org/openstack4j/model/magnum/Bay.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Bay.java
@@ -1,0 +1,73 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface Bay extends ModelEntity, Buildable<BayBuilder> {
+    /**
+     * Gets status
+     * @return status
+     */
+    String getStatus();
+
+
+    /**
+     * Gets uuid
+     * @return uuid
+     */
+    String getUuid();
+
+
+    /**
+     * Gets links
+     * @return links
+     */
+    List<GenericLink> getLinks();
+
+
+    /**
+     * Gets stackId
+     * @return stackId
+     */
+    String getStackId();
+
+
+    /**
+     * Gets masterCount
+     * @return masterCount
+     */
+    Integer getMasterCount();
+
+
+    /**
+     * Gets baymodelId
+     * @return baymodelId
+     */
+    String getBaymodelId();
+
+
+    /**
+     * Gets nodeCount
+     * @return nodeCount
+     */
+    Integer getNodeCount();
+
+
+    /**
+     * Gets bayCreateTimeout
+     * @return bayCreateTimeout
+     */
+    String getBayCreateTimeout();
+
+
+    /**
+     * Gets name
+     * @return name
+     */
+    String getName();
+
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/BayBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/BayBuilder.java
@@ -1,0 +1,63 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface BayBuilder extends Builder<BayBuilder, Bay> {
+    /**
+     * @see Bay#getStatus
+     */
+    BayBuilder status(String status);
+
+
+    /**
+     * @see Bay#getUuid
+     */
+    BayBuilder uuid(String uuid);
+
+
+    /**
+     * @see Bay#getLinks
+     */
+    BayBuilder links(List<GenericLink> links);
+
+
+    /**
+     * @see Bay#getStackId
+     */
+    BayBuilder stackId(String stackId);
+
+
+    /**
+     * @see Bay#getMasterCount
+     */
+    BayBuilder masterCount(Integer masterCount);
+
+
+    /**
+     * @see Bay#getBaymodelId
+     */
+    BayBuilder baymodelId(String baymodelId);
+
+
+    /**
+     * @see Bay#getNodeCount
+     */
+    BayBuilder nodeCount(Integer nodeCount);
+
+
+    /**
+     * @see Bay#getBayCreateTimeout
+     */
+    BayBuilder bayCreateTimeout(String bayCreateTimeout);
+
+
+    /**
+     * @see Bay#getName
+     */
+    BayBuilder name(String name);
+
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Baymodel.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Baymodel.java
@@ -1,0 +1,190 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+import java.util.Map;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface Baymodel extends ModelEntity, Buildable<BaymodelBuilder> {
+    /**
+     * Insecure registry
+     * @return InsecureRegistry
+     */
+    String getInsecureRegistry(); 
+    
+    /**
+     * All links
+     * @return links
+     */
+    List<GenericLink> getLinks();
+    
+    /**
+     * Http proxy
+     * @return httpProxy
+     */
+    String getHttpProxy();
+    
+    /**
+     * Updated time
+     * @return updatedAt
+     */
+    String getUpdatedAt(); 
+    
+    /**
+     * Is Floating IP enabled
+     * @return floatingIpEnabled
+     */
+    Boolean isFloatingIpEnabled();
+    
+    /**
+     * Fixed subnet
+     * @return fixedSubnet
+     */
+    String getFixedSubnet();
+    
+    /**
+     * Master flavor id
+     * @return masterFlavorId
+     */
+    String getMasterFlavorId(); 
+    
+    /**
+     * UUID
+     * @return uuid
+     */
+    String getUuid(); 
+    
+    /**
+     * No proxy
+     * @return noProxy
+     */
+    String getNoProxy(); 
+    
+    /**
+     * Http proxy
+     * @return http proxy
+     */
+    String getHttpsProxy(); 
+    
+    /**
+     * Is TLS disabled
+     * @return tlsDisabled boolean value
+     */
+    Boolean isTlsDisabled(); 
+    
+    /**
+     * Keypair id
+     * @return keypairId
+     */
+    String getKeypairId(); 
+    
+    /**
+     * Is it public
+     * @return public boolean vallue
+     */
+    Boolean isPublicBaymodel(); 
+    
+    /**
+     * Docker volume size
+     * @return dockerVolumeSize
+     */
+    String getDockerVolumeSize();
+    
+    /**
+     * Server type
+     * @return serverType
+     */
+    String getServerType();
+    
+    /**
+     * External network id
+     * @return externalNetworkId
+     */
+    String getExternalNetworkId();
+    
+    /**
+     * Cluster distro
+     * @return clusterDistro
+     */
+    String getClusterDistro();
+    
+    /**
+     * Imdage id
+     * @return imageId
+     */
+    String getImageId(); 
+    
+    /**
+     * Volume driver
+     * @return volume driver
+     */
+    String getVolumeDriver(); 
+    
+    /**
+     * Is registry enabled
+     * @return registryEnabled boolean value
+     */
+    Boolean isRegistryEnabled(); 
+    
+    /**
+     * Docker storage driver
+     * @return dockerStorageDriver
+     */
+    String getDockerStorageDriver();
+    
+    /**
+     * Api server port
+     * @return apiserverPort
+     */
+    String getApiserverPort();
+    
+    /**
+     * Name
+     * @return name
+     */
+    String getName(); 
+    
+    /**
+     * Date of creation
+     * @return createdAt
+     */
+    String getCreatedAt(); 
+    
+    /**
+     * Network driver
+     * @return networkDriver
+     */
+    String getNetworkDriver(); 
+    
+    /**
+     * Fixed network
+     * @return fixedNetwork
+     */
+    String getFixedNetwork(); 
+    
+    /**
+     * Coe
+     * @return coe
+     */
+    String getCoe();
+    
+    /**
+     * Flavor id
+     * @return flavorId
+     */
+    String getFlavorId(); 
+    
+    /**
+     * Is master lb enabled
+     * @return masterLbEnabled boolean value
+     */
+    Boolean isMasterLbEnabled(); 
+    
+    /**
+     * DNS name server
+     * @return dnsNameServer
+     */
+    String getDnsNameserver();   
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/BaymodelBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/BaymodelBuilder.java
@@ -1,0 +1,160 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+import java.util.Map;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface BaymodelBuilder extends Builder<BaymodelBuilder, Baymodel> {
+    /**
+     * @see Baymodel#getInsecureRegistry()
+     */
+    BaymodelBuilder insecureRegistry(String insecureRegistry);
+
+    /**
+     * @see Baymodel#getLinks()
+     */
+    BaymodelBuilder links(List<GenericLink> links);
+
+    /**
+     * @see Baymodel#getHttpProxy()
+     */
+    BaymodelBuilder httpProxy(String httpProxy);
+
+    /**
+     * @see Baymodel#getUpdatedAt()
+     */
+    BaymodelBuilder updatedAt(String updatedAt);
+
+    /**
+     * @see Baymodel#getisFloatingIpEnabled()
+     */
+    BaymodelBuilder isFloatingIpEnabled(Boolean floatingIpEnabled);
+
+    /**
+     * @see Baymodel#getFixedSubnet()
+     */
+    BaymodelBuilder fixedSubnet(String fixedSubnet);
+
+    /**
+     * @see Baymodel#getMasterFlavorId()
+     */
+    BaymodelBuilder masterFlavorId(String masterFlavorId);
+
+    /**
+     * @see Baymodel#getUuid()
+     */
+    BaymodelBuilder uuid(String uuid);
+
+    /**
+     * @see Baymodel#getNoProxy()
+     */
+    BaymodelBuilder noProxy(String noProxy);
+
+    /**
+     * @see Baymodel#getHttpsProxy()
+     */
+    BaymodelBuilder httpsProxy(String httpsProxy);
+
+    /**
+     * @see Baymodel#getTlsDisabled()
+     */
+    BaymodelBuilder tlsDisabled(Boolean tlsDisabled);
+
+    /**
+     * @see Baymodel#getKeypairId()
+     */
+    BaymodelBuilder keypairId(String keypairId);
+
+    /**
+     * @see Baymodel#getPublicBaymodel()
+     */
+    BaymodelBuilder publicBaymodel(Boolean publicBaymodel);
+
+    /**
+     * @see Baymodel#getDockerVolumeSize()
+     */
+    BaymodelBuilder dockerVolumeSize(String dockerVolumeSize);
+
+    /**
+     * @see Baymodel#getServerType()
+     */
+    BaymodelBuilder serverType(String serverType);
+
+    /**
+     * @see Baymodel#getExternalNetworkId()
+     */
+    BaymodelBuilder externalNetworkId(String externalNetworkId);
+
+    /**
+     * @see Baymodel#getClusterDistro()
+     */
+    BaymodelBuilder clusterDistro(String clusterDistro);
+
+    /**
+     * @see Baymodel#getImageId()
+     */
+    BaymodelBuilder imageId(String imageId);
+
+    /**
+     * @see Baymodel#getVolumeDriver()
+     */
+    BaymodelBuilder volumeDriver(String volumeDriver);
+
+    /**
+     * @see Baymodel#getRegistryEnabled()
+     */
+    BaymodelBuilder registryEnabled(Boolean registryEnabled);
+
+    /**
+     * @see Baymodel#getDockerStorageDriver()
+     */
+    BaymodelBuilder dockerStorageDriver(String dockerStorageDriver);
+
+    /**
+     * @see Baymodel#getApiserverPort()
+     */
+    BaymodelBuilder apiserverPort(String apiserverPort);
+
+    /**
+     * @see Baymodel#getName()
+     */
+    BaymodelBuilder name(String name);
+
+    /**
+     * @see Baymodel#getCreatedAt()
+     */
+    BaymodelBuilder createdAt(String createdAt);
+
+    /**
+     * @see Baymodel#getNetworkDriver()
+     */
+    BaymodelBuilder networkDriver(String networkDriver);
+
+    /**
+     * @see Baymodel#getFixedNetwork()
+     */
+    BaymodelBuilder fixedNetwork(String fixedNetwork);
+
+    /**
+     * @see Baymodel#getCoe()
+     */
+    BaymodelBuilder coe(String coe);
+
+    /**
+     * @see Baymodel#getFlavorId()
+     */
+    BaymodelBuilder flavorId(String flavorId);
+
+    /**
+     * @see Baymodel#getMasterLbEnabled()
+     */
+    BaymodelBuilder masterLbEnabled(Boolean masterLbEnabled);
+
+    /**
+     * @see Baymodel#getDnsNameserver()
+     */
+    BaymodelBuilder dnsNameserver(String dnsNameserver);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Carequest.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Carequest.java
@@ -1,0 +1,21 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+
+public interface Carequest extends ModelEntity, Buildable<CarequestBuilder> {
+    /**
+     * Gets bayUuid
+     * 
+     * @return bayUuid
+     */
+    String getBayUuid();
+
+    /**
+     * Gets csr
+     * 
+     * @return csr
+     */
+    String getCsr();
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/CarequestBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/CarequestBuilder.java
@@ -1,0 +1,16 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable.Builder;
+
+public interface CarequestBuilder extends Builder<CarequestBuilder, Carequest> {
+    /**
+     * @see Carequest#getBayUuid
+     */
+    CarequestBuilder bayUuid(String bayUuid);
+
+    /**
+     * @see Carequest#getCsr
+     */
+    CarequestBuilder csr(String csr);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Certificate.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Certificate.java
@@ -1,0 +1,31 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface Certificate extends ModelEntity, Buildable<CertificateBuilder> {
+    /**
+     * Gets pem
+     * 
+     * @return pem
+     */
+    String getPem();
+
+    /**
+     * Gets bayUuid
+     * 
+     * @return bayUuid
+     */
+    String getBayUuid();
+
+    /**
+     * Gets links
+     * 
+     * @return links
+     */
+    List<GenericLink> getLinks();
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/CertificateBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/CertificateBuilder.java
@@ -1,0 +1,24 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface CertificateBuilder extends Builder<CertificateBuilder, Certificate> {
+    /**
+     * @see Certificate#getPem
+     */
+    CertificateBuilder pem(String pem);
+
+    /**
+     * @see Certificate#getBayUuid
+     */
+    CertificateBuilder bayUuid(String bayUuid);
+
+    /**
+     * @see Certificate#getLinks
+     */
+    CertificateBuilder links(List<GenericLink> links);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Cluster.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Cluster.java
@@ -1,0 +1,87 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface Cluster extends ModelEntity, Buildable<ClusterBuilder> {
+    /**
+     * Gets status
+     * 
+     * @return status
+     */
+    String getStatus();
+
+    /**
+     * Gets clusterTemplateId
+     * 
+     * @return clusterTemplateId
+     */
+    String getClusterTemplateId();
+
+    /**
+     * Gets uuid
+     * 
+     * @return uuid
+     */
+    String getUuid();
+
+    /**
+     * Gets links
+     * 
+     * @return links
+     */
+    List<GenericLink> getLinks();
+
+    /**
+     * Gets stackId
+     * 
+     * @return stackId
+     */
+    String getStackId();
+
+    /**
+     * Gets masterCount
+     * 
+     * @return masterCount
+     */
+    Integer getMasterCount();
+
+    /**
+     * Gets createTimeout
+     * 
+     * @return createTimeout
+     */
+    Integer getCreateTimeout();
+
+    /**
+     * Gets nodeCount
+     * 
+     * @return nodeCount
+     */
+    Integer getNodeCount();
+
+    /**
+     * Gets discoveryUrl
+     * 
+     * @return discoveryUrl
+     */
+    String getDiscoveryUrl();
+
+    /**
+     * Gets keypair
+     * 
+     * @return keypair
+     */
+    String getKeypair();
+
+    /**
+     * Gets name
+     * 
+     * @return name
+     */
+    String getName();
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/ClusterBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/ClusterBuilder.java
@@ -1,0 +1,64 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface ClusterBuilder extends Builder<ClusterBuilder, Cluster> {
+    /**
+     * @see Cluster#getStatus
+     */
+    ClusterBuilder status(String status);
+
+    /**
+     * @see Cluster#getClusterTemplateId
+     */
+    ClusterBuilder clusterTemplateId(String clusterTemplateId);
+
+    /**
+     * @see Cluster#getUuid
+     */
+    ClusterBuilder uuid(String uuid);
+
+    /**
+     * @see Cluster#getLinks
+     */
+    ClusterBuilder links(List<GenericLink> links);
+
+    /**
+     * @see Cluster#getStackId
+     */
+    ClusterBuilder stackId(String stackId);
+
+    /**
+     * @see Cluster#getMasterCount
+     */
+    ClusterBuilder masterCount(Integer masterCount);
+
+    /**
+     * @see Cluster#getCreateTimeout
+     */
+    ClusterBuilder createTimeout(Integer createTimeout);
+
+    /**
+     * @see Cluster#getNodeCount
+     */
+    ClusterBuilder nodeCount(Integer nodeCount);
+
+    /**
+     * @see Cluster#getDiscoveryUrl
+     */
+    ClusterBuilder discoveryUrl(String discoveryUrl);
+
+    /**
+     * @see Cluster#getKeypair
+     */
+    ClusterBuilder keypair(String keypair);
+
+    /**
+     * @see Cluster#getName
+     */
+    ClusterBuilder name(String name);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Clustertemplate.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Clustertemplate.java
@@ -1,0 +1,227 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface Clustertemplate extends ModelEntity, Buildable<ClustertemplateBuilder> {
+    /**
+     * Gets insecureRegistry
+     * 
+     * @return insecureRegistry
+     */
+    String getInsecureRegistry();
+
+    /**
+     * Gets links
+     * 
+     * @return links
+     */
+    List<GenericLink> getLinks();
+
+    /**
+     * Gets httpProxy
+     * 
+     * @return httpProxy
+     */
+    String getHttpProxy();
+
+    /**
+     * Gets updatedAt
+     * 
+     * @return updatedAt
+     */
+    String getUpdatedAt();
+
+    /**
+     * Gets floatingIpEnabled
+     * 
+     * @return floatingIpEnabled
+     */
+    Boolean getFloatingIpEnabled();
+
+    /**
+     * Gets fixedSubnet
+     * 
+     * @return fixedSubnet
+     */
+    String getFixedSubnet();
+
+    /**
+     * Gets masterFlavorId
+     * 
+     * @return masterFlavorId
+     */
+    String getMasterFlavorId();
+
+    /**
+     * Gets uuid
+     * 
+     * @return uuid
+     */
+    String getUuid();
+
+    /**
+     * Gets noProxy
+     * 
+     * @return noProxy
+     */
+    String getNoProxy();
+
+    /**
+     * Gets httpsProxy
+     * 
+     * @return httpsProxy
+     */
+    String getHttpsProxy();
+
+    /**
+     * Gets tlsDisabled
+     * 
+     * @return tlsDisabled
+     */
+    Boolean getTlsDisabled();
+
+    /**
+     * Gets keypairId
+     * 
+     * @return keypairId
+     */
+    String getKeypairId();
+
+    /**
+     * Gets publicTemplate
+     * 
+     * @return publicTemplate
+     */
+    Boolean getPublicTemplate();
+
+    /**
+     * Gets labels
+     * 
+     * @return labels
+     */
+    Label getLabels();
+
+    /**
+     * Gets dockerVolumeSize
+     * 
+     * @return dockerVolumeSize
+     */
+    Integer getDockerVolumeSize();
+
+    /**
+     * Gets serverType
+     * 
+     * @return serverType
+     */
+    String getServerType();
+
+    /**
+     * Gets externalNetworkId
+     * 
+     * @return externalNetworkId
+     */
+    String getExternalNetworkId();
+
+    /**
+     * Gets clusterDistro
+     * 
+     * @return clusterDistro
+     */
+    String getClusterDistro();
+
+    /**
+     * Gets imageId
+     * 
+     * @return imageId
+     */
+    String getImageId();
+
+    /**
+     * Gets volumeDriver
+     * 
+     * @return volumeDriver
+     */
+    String getVolumeDriver();
+
+    /**
+     * Gets registryEnabled
+     * 
+     * @return registryEnabled
+     */
+    Boolean getRegistryEnabled();
+
+    /**
+     * Gets dockerStorageDriver
+     * 
+     * @return dockerStorageDriver
+     */
+    String getDockerStorageDriver();
+
+    /**
+     * Gets apiserverPort
+     * 
+     * @return apiserverPort
+     */
+    String getApiserverPort();
+
+    /**
+     * Gets name
+     * 
+     * @return name
+     */
+    String getName();
+
+    /**
+     * Gets createdAt
+     * 
+     * @return createdAt
+     */
+    String getCreatedAt();
+
+    /**
+     * Gets networkDriver
+     * 
+     * @return networkDriver
+     */
+    String getNetworkDriver();
+
+    /**
+     * Gets fixedNetwork
+     * 
+     * @return fixedNetwork
+     */
+    String getFixedNetwork();
+
+    /**
+     * Gets coe
+     * 
+     * @return coe
+     */
+    String getCoe();
+
+    /**
+     * Gets flavorId
+     * 
+     * @return flavorId
+     */
+    String getFlavorId();
+
+    /**
+     * Gets masterLbEnabled
+     * 
+     * @return masterLbEnabled
+     */
+    Boolean getMasterLbEnabled();
+
+    /**
+     * Gets dnsNameserver
+     * 
+     * @return dnsNameserver
+     */
+    String getDnsNameserver();
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/ClustertemplateBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/ClustertemplateBuilder.java
@@ -1,0 +1,164 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.openstack.common.GenericLink;
+
+public interface ClustertemplateBuilder extends Builder<ClustertemplateBuilder, Clustertemplate> {
+    /**
+     * @see Clustertemplate#getInsecureRegistry
+     */
+    ClustertemplateBuilder insecureRegistry(String insecureRegistry);
+
+    /**
+     * @see Clustertemplate#getLinks
+     */
+    ClustertemplateBuilder links(List<GenericLink> links);
+
+    /**
+     * @see Clustertemplate#getHttpProxy
+     */
+    ClustertemplateBuilder httpProxy(String httpProxy);
+
+    /**
+     * @see Clustertemplate#getUpdatedAt
+     */
+    ClustertemplateBuilder updatedAt(String updatedAt);
+
+    /**
+     * @see Clustertemplate#getFloatingIpEnabled
+     */
+    ClustertemplateBuilder floatingIpEnabled(Boolean floatingIpEnabled);
+
+    /**
+     * @see Clustertemplate#getFixedSubnet
+     */
+    ClustertemplateBuilder fixedSubnet(String fixedSubnet);
+
+    /**
+     * @see Clustertemplate#getMasterFlavorId
+     */
+    ClustertemplateBuilder masterFlavorId(String masterFlavorId);
+
+    /**
+     * @see Clustertemplate#getUuid
+     */
+    ClustertemplateBuilder uuid(String uuid);
+
+    /**
+     * @see Clustertemplate#getNoProxy
+     */
+    ClustertemplateBuilder noProxy(String noProxy);
+
+    /**
+     * @see Clustertemplate#getHttpsProxy
+     */
+    ClustertemplateBuilder httpsProxy(String httpsProxy);
+
+    /**
+     * @see Clustertemplate#getTlsDisabled
+     */
+    ClustertemplateBuilder tlsDisabled(Boolean tlsDisabled);
+
+    /**
+     * @see Clustertemplate#getKeypairId
+     */
+    ClustertemplateBuilder keypairId(String keypairId);
+
+    /**
+     * @see Clustertemplate#getPublicTemplate
+     */
+    ClustertemplateBuilder publicTemplate(Boolean publicTemplate);
+
+    /**
+     * @see Clustertemplate#getLabels
+     */
+    ClustertemplateBuilder labels(Label labels);
+
+    /**
+     * @see Clustertemplate#getDockerVolumeSize
+     */
+    ClustertemplateBuilder dockerVolumeSize(Integer dockerVolumeSize);
+
+    /**
+     * @see Clustertemplate#getServerType
+     */
+    ClustertemplateBuilder serverType(String serverType);
+
+    /**
+     * @see Clustertemplate#getExternalNetworkId
+     */
+    ClustertemplateBuilder externalNetworkId(String externalNetworkId);
+
+    /**
+     * @see Clustertemplate#getClusterDistro
+     */
+    ClustertemplateBuilder clusterDistro(String clusterDistro);
+
+    /**
+     * @see Clustertemplate#getImageId
+     */
+    ClustertemplateBuilder imageId(String imageId);
+
+    /**
+     * @see Clustertemplate#getVolumeDriver
+     */
+    ClustertemplateBuilder volumeDriver(String volumeDriver);
+
+    /**
+     * @see Clustertemplate#getRegistryEnabled
+     */
+    ClustertemplateBuilder registryEnabled(Boolean registryEnabled);
+
+    /**
+     * @see Clustertemplate#getDockerStorageDriver
+     */
+    ClustertemplateBuilder dockerStorageDriver(String dockerStorageDriver);
+
+    /**
+     * @see Clustertemplate#getApiserverPort
+     */
+    ClustertemplateBuilder apiserverPort(String apiserverPort);
+
+    /**
+     * @see Clustertemplate#getName
+     */
+    ClustertemplateBuilder name(String name);
+
+    /**
+     * @see Clustertemplate#getCreatedAt
+     */
+    ClustertemplateBuilder createdAt(String createdAt);
+
+    /**
+     * @see Clustertemplate#getNetworkDriver
+     */
+    ClustertemplateBuilder networkDriver(String networkDriver);
+
+    /**
+     * @see Clustertemplate#getFixedNetwork
+     */
+    ClustertemplateBuilder fixedNetwork(String fixedNetwork);
+
+    /**
+     * @see Clustertemplate#getCoe
+     */
+    ClustertemplateBuilder coe(String coe);
+
+    /**
+     * @see Clustertemplate#getFlavorId
+     */
+    ClustertemplateBuilder flavorId(String flavorId);
+
+    /**
+     * @see Clustertemplate#getMasterLbEnabled
+     */
+    ClustertemplateBuilder masterLbEnabled(Boolean masterLbEnabled);
+
+    /**
+     * @see Clustertemplate#getDnsNameserver
+     */
+    ClustertemplateBuilder dnsNameserver(String dnsNameserver);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Container.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Container.java
@@ -1,0 +1,74 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.magnum.MagnumEnvironment;
+
+public interface Container extends ModelEntity, Buildable<ContainerBuilder> {
+    /**
+     * Gets status
+     * 
+     * @return status
+     */
+    String getStatus();
+
+    /**
+     * Gets uuid
+     * 
+     * @return uuid
+     */
+    String getUuid();
+
+    /**
+     * Gets links
+     * 
+     * @return links
+     */
+    List<GenericLink> getLinks();
+
+    /**
+     * Gets image
+     * 
+     * @return image
+     */
+    String getImage();
+
+    /**
+     * Gets environment
+     * 
+     * @return environment
+     */
+    MagnumEnvironment getEnvironment();
+
+    /**
+     * Gets command
+     * 
+     * @return command
+     */
+    String getCommand();
+
+    /**
+     * Gets memory
+     * 
+     * @return memory
+     */
+    String getMemory();
+
+    /**
+     * Gets bayUuid
+     * 
+     * @return bayUuid
+     */
+    String getBayUuid();
+
+    /**
+     * Gets name
+     * 
+     * @return name
+     */
+    String getName();
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/ContainerBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/ContainerBuilder.java
@@ -1,0 +1,56 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.magnum.MagnumEnvironment;
+
+
+public interface ContainerBuilder extends Builder<ContainerBuilder, Container> {
+    /**
+     * @see Container#getStatus
+     */
+    ContainerBuilder status(String status);
+
+    /**
+     * @see Container#getUuid
+     */
+    ContainerBuilder uuid(String uuid);
+
+    /**
+     * @see Container#getLinks
+     */
+    ContainerBuilder links(List<GenericLink> links);
+
+    /**
+     * @see Container#getImage
+     */
+    ContainerBuilder image(String image);
+
+    /**
+     * @see Container#getEnvironment
+     */
+    ContainerBuilder environment(MagnumEnvironment environment);
+
+    /**
+     * @see Container#getCommand
+     */
+    ContainerBuilder command(String command);
+
+    /**
+     * @see Container#getMemory
+     */
+    ContainerBuilder memory(String memory);
+
+    /**
+     * @see Container#getBayUuid
+     */
+    ContainerBuilder bayUuid(String bayUuid);
+
+    /**
+     * @see Container#getName
+     */
+    ContainerBuilder name(String name);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Environment.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Environment.java
@@ -1,0 +1,21 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+
+public interface Environment extends ModelEntity, Buildable<EnvironmentBuilder> {
+    /**
+     * Gets path
+     * @return path
+     */
+    String getPath();
+
+
+    /**
+     * Gets ldLibraryPath
+     * @return ldLibraryPath
+     */
+    String getLdLibraryPath();
+
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/EnvironmentBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/EnvironmentBuilder.java
@@ -1,0 +1,16 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable.Builder;
+
+public interface EnvironmentBuilder extends Builder<EnvironmentBuilder, Environment> {
+    /**
+     * @see Environment#getPath
+     */
+    EnvironmentBuilder path(String path);
+
+    /**
+     * @see Environment#getLdLibraryPath
+     */
+    EnvironmentBuilder ldLibraryPath(String ldLibraryPath);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Label.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Label.java
@@ -1,0 +1,14 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+
+public interface Label extends ModelEntity, Buildable<LabelBuilder> {
+    /**
+     * Gets key
+     * 
+     * @return key
+     */
+    String getKey();
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/LabelBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/LabelBuilder.java
@@ -1,0 +1,11 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable.Builder;
+
+public interface LabelBuilder extends Builder<LabelBuilder, Label> {
+    /**
+     * @see Label#getKey
+     */
+    LabelBuilder key(String key);
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Mservice.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Mservice.java
@@ -1,0 +1,63 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+
+public interface Mservice extends ModelEntity, Buildable<MserviceBuilder>{
+	
+	/**
+	 * Identifier of Magnum Service
+	 * 
+	 * @return the of Magnum Service
+	 */
+	String getId();
+	
+	/**
+	 * Binary of the service
+	 * 
+	 * @return the binary of the service
+	 */
+	String getBinary();
+	
+	/**
+	 * Creation date
+	 * 
+	 * @return the date of creation
+	 */
+	String getCreatedAt();
+	
+	/**
+	 * Current state if it is up or not
+	 * 
+	 * @return the state of the service
+	 */
+	String getState();
+	
+	/**
+	 * Report count
+	 * 
+	 * @return the report count of the service
+	 */
+	int getReportCount();
+	
+	/**
+	 * The date of last updation
+	 * 
+	 * @return the last updated time
+	 */
+	String getUpdatedAt();
+	
+	/** 
+	 * The host name
+	 * 
+	 * @return the host name
+	 */
+	String getHost();
+	
+	/**
+	 * The disabled reason
+	 * 
+	 * @return the disabled reason
+	 */
+	String getDisabledReason();
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/MserviceBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/MserviceBuilder.java
@@ -1,0 +1,52 @@
+package org.openstack4j.model.magnum;
+
+import org.openstack4j.common.Buildable.Builder;
+
+/**
+ * Builder which crates Magnum Service
+ * 
+ * @author Sohan Sangwan
+ *
+ */
+		
+public interface MserviceBuilder extends Builder<MserviceBuilder, Mservice> {
+	 /**
+     * @see Mservice#getId()
+     */
+	MserviceBuilder id(String id);
+	
+	 /**
+     * @see Mservice#getBinary()
+     */
+	MserviceBuilder binary(String binary);
+	
+	 /**
+     * @see Mservice#getCreatedAt()
+     */
+	MserviceBuilder createdAt(String createdAt);
+	
+	 /**
+     * @see Mservice#getState()
+     */
+	MserviceBuilder state(String state);
+	
+	 /**
+     * @see Mservice#getReportCount()
+     */
+	MserviceBuilder reportCount(int reportCount);
+	
+	 /**
+     * @see Mservice#getUpdatedAt()
+     */
+	MserviceBuilder updatedAt(String updatedAt);
+	
+	 /**
+     * @see Mservice#getHost()
+     */
+	MserviceBuilder host(String host);
+	
+	 /**
+     * @see Mservice#getDisabledReason()
+     */
+	MserviceBuilder disabledReason(String disabledReason);
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/Pod.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/Pod.java
@@ -1,0 +1,65 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+
+public interface Pod extends ModelEntity, Buildable<PodBuilder> {
+    /**
+     * Gets id
+     * 
+     * @return id
+     */
+    String getId();
+
+    /**
+     * Gets uuid
+     * 
+     * @return uuid
+     */
+    String getUuid();
+
+    /**
+     * Gets name
+     * 
+     * @return name
+     */
+    String getName();
+
+    /**
+     * Gets desc
+     * 
+     * @return desc
+     */
+    String getDesc();
+
+    /**
+     * Gets bayUuid
+     * 
+     * @return bayUuid
+     */
+    String getBayUuid();
+
+    /**
+     * Gets images
+     * 
+     * @return images
+     */
+    List<String> getImages();
+
+    /**
+     * Gets labels
+     * 
+     * @return labels
+     */
+    Label getLabels();
+
+    /**
+     * Gets status
+     * 
+     * @return status
+     */
+    String getStatus();
+
+}

--- a/core/src/main/java/org/openstack4j/model/magnum/PodBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/magnum/PodBuilder.java
@@ -1,0 +1,48 @@
+package org.openstack4j.model.magnum;
+
+import java.util.List;
+
+import org.openstack4j.common.Buildable.Builder;
+
+public interface PodBuilder extends Builder<PodBuilder, Pod> {
+    /**
+     * @see Pod#getId
+     */
+    PodBuilder id(String id);
+
+    /**
+     * @see Pod#getUuid
+     */
+    PodBuilder uuid(String uuid);
+
+    /**
+     * @see Pod#getName
+     */
+    PodBuilder name(String name);
+
+    /**
+     * @see Pod#getDesc
+     */
+    PodBuilder desc(String desc);
+
+    /**
+     * @see Pod#getBayUuid
+     */
+    PodBuilder bayUuid(String bayUuid);
+
+    /**
+     * @see Pod#getImages
+     */
+    PodBuilder images(List<String> images);
+
+    /**
+     * @see Pod#getLabels
+     */
+    PodBuilder labels(Label labels);
+
+    /**
+     * @see Pod#getStatus
+     */
+    PodBuilder status(String status);
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -16,6 +16,7 @@ import org.openstack4j.api.gbp.GbpService;
 import org.openstack4j.api.heat.HeatService;
 import org.openstack4j.api.identity.EndpointURLResolver;
 import org.openstack4j.api.image.ImageService;
+import org.openstack4j.api.magnum.MagnumService;
 import org.openstack4j.api.manila.ShareService;
 import org.openstack4j.api.murano.v1.AppCatalogService;
 import org.openstack4j.api.networking.NetworkingService;
@@ -176,6 +177,13 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
      */
     public AppCatalogService murano() {
         return Apis.getMuranoServices();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public MagnumService magnum() {
+    	return Apis.getMagnumService();
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumBay.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumBay.java
@@ -1,0 +1,178 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+import org.openstack4j.model.magnum.Bay;
+import org.openstack4j.model.magnum.BayBuilder;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+public class MagnumBay implements Bay {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("uuid")
+    private String uuid;
+    @JsonProperty("links")
+    private List<GenericLink> links;
+    @JsonProperty("stack_id")
+    private String stackId;
+    @JsonProperty("master_count")
+    private Integer masterCount;
+    @JsonProperty("baymodel_id")
+    private String baymodelId;
+    @JsonProperty("node_count")
+    private Integer nodeCount;
+    @JsonProperty("bay_create_timeout")
+    private String bayCreateTimeout;
+    @JsonProperty("name")
+    private String name;
+
+    public static BayBuilder builder() {
+        return new BayConcreteBuilder();
+    }
+    
+    @Override
+    public BayBuilder toBuilder() {
+        return new BayConcreteBuilder(this);
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public List<GenericLink> getLinks() {
+        return links;
+    }
+
+    public String getStackId() {
+        return stackId;
+    }
+
+    public Integer getMasterCount() {
+        return masterCount;
+    }
+
+    public String getBaymodelId() {
+        return baymodelId;
+    }
+
+    public Integer getNodeCount() {
+        return nodeCount;
+    }
+
+    public String getBayCreateTimeout() {
+        return bayCreateTimeout;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("status", status).add("uuid", uuid).add("links", links)
+                .add("stackId", stackId).add("masterCount", masterCount).add("baymodelId", baymodelId)
+                .add("nodeCount", nodeCount).add("bayCreateTimeout", bayCreateTimeout).add("name", name).toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumBay as model
+     *
+     */
+    public static class BayConcreteBuilder implements BayBuilder {
+        MagnumBay model;
+
+        public BayConcreteBuilder() {
+            this(new MagnumBay());
+        }
+
+        public BayConcreteBuilder(MagnumBay model) {
+            this.model = model;
+        }
+
+        @Override
+        public Bay build() {
+            return model;
+        }
+
+        @Override
+        public BayBuilder from(Bay in) {
+            if (in != null)
+                this.model = (MagnumBay) in;
+            return this;
+        }
+
+        @Override
+        public BayBuilder status(String status) {
+            model.status = status;
+            return this;
+        }
+
+        @Override
+        public BayBuilder uuid(String uuid) {
+            model.uuid = uuid;
+            return this;
+        }
+
+        @Override
+        public BayBuilder links(List<GenericLink> links) {
+            model.links = links;
+            return this;
+        }
+
+        @Override
+        public BayBuilder stackId(String stackId) {
+            model.stackId = stackId;
+            return this;
+        }
+
+        @Override
+        public BayBuilder masterCount(Integer masterCount) {
+            model.masterCount = masterCount;
+            return this;
+        }
+
+        @Override
+        public BayBuilder baymodelId(String baymodelId) {
+            model.baymodelId = baymodelId;
+            return this;
+        }
+
+        @Override
+        public BayBuilder nodeCount(Integer nodeCount) {
+            model.nodeCount = nodeCount;
+            return this;
+        }
+
+        @Override
+        public BayBuilder bayCreateTimeout(String bayCreateTimeout) {
+            model.bayCreateTimeout = bayCreateTimeout;
+            return this;
+        }
+
+        @Override
+        public BayBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+
+        public static class Bays extends ListResult<MagnumBay> {
+            private static final long serialVersionUID = 1L;
+            @JsonProperty("bays")
+            private List<MagnumBay> list;
+
+            @Override
+            public List<MagnumBay> value() {
+                return list;
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumBaymodel.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumBaymodel.java
@@ -1,0 +1,457 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+import org.openstack4j.model.magnum.Baymodel;
+import org.openstack4j.model.magnum.BaymodelBuilder;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumBaymodel implements Baymodel{
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    
+    @JsonProperty("insecure_registry")
+    private String insecureRegistry;
+    @JsonProperty("links")
+    private List<GenericLink> links;
+    @JsonProperty("http_proxy")
+    private String httpProxy;
+    @JsonProperty("updated_at")
+    private String updatedAt;
+    @JsonProperty("floating_ip_enabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean floatingIpEnabled;
+    @JsonProperty("fixed_subnet")
+    private String fixedSubnet;
+    @JsonProperty("master_flavor_id")
+    private String masterFlavorId;
+    @JsonProperty("uuid")
+    private String uuid;
+    @JsonProperty("no_proxy")
+    private String noProxy;
+    @JsonProperty("https_proxy")
+    private String httpsProxy;
+    @JsonProperty("tls_disabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean tlsDisabled;
+    @JsonProperty("keypair_id")
+    private String keypairId;
+    @JsonProperty("public")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean publicBaymodel;
+    //@JsonProperty("labels")
+    @JsonProperty("docker_volume_size")
+    private String dockerVolumeSize;
+    @JsonProperty("server_type")
+    private String serverType;
+    @JsonProperty("external_network_id")
+    private String externalNetworkId;
+    @JsonProperty("cluster_distro")
+    private String clusterDistro;
+    @JsonProperty("image_id")
+    private String imageId;
+    @JsonProperty("volume_driver")
+    private String volumeDriver;
+    @JsonProperty("registry_enabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean registryEnabled;
+    @JsonProperty("docker_storage_driver")
+    private String dockerStorageDriver;
+    @JsonProperty("apiserver_port")
+    private String apiserverPort;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("created_at")
+    private String createdAt;
+    @JsonProperty("network_driver")
+    private String networkDriver;
+    @JsonProperty("fixed_network")
+    private String fixedNetwork;
+    @JsonProperty("coe")
+    private String coe;
+    @JsonProperty("flavor_id")
+    private String flavorId;
+    @JsonProperty("master_lb_enabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean masterLbEnabled;
+    @JsonProperty("dns_nameserver")
+    private String dnsNameserver;
+    
+    public static BaymodelBuilder builder() {
+        return new BaymodelConcreteBuilder();
+    }
+    @Override
+    public BaymodelBuilder toBuilder() {
+        
+        return new BaymodelConcreteBuilder(this);
+    }
+    
+    public String getInsecureRegistry() {
+        return insecureRegistry;
+    }
+    public List<GenericLink> getLinks() {
+        return links;
+    }
+    public String getHttpProxy() {
+        return httpProxy;
+    }
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+    public Boolean isFloatingIpEnabled() {
+        return floatingIpEnabled;
+    }
+    public String getFixedSubnet() {
+        return fixedSubnet;
+    }
+    public String getMasterFlavorId() {
+        return masterFlavorId;
+    }
+    public String getUuid() {
+        return uuid;
+    }
+    public String getNoProxy() {
+        return noProxy;
+    }
+    public String getHttpsProxy() {
+        return httpsProxy;
+    }
+    public Boolean isTlsDisabled() {
+        return tlsDisabled;
+    }
+    public String getKeypairId() {
+        return keypairId;
+    }
+    public Boolean isPublicBaymodel() {
+        return publicBaymodel;
+    }
+    public String getDockerVolumeSize() {
+        return dockerVolumeSize;
+    }
+    public String getServerType() {
+        return serverType;
+    }
+    public String getExternalNetworkId() {
+        return externalNetworkId;
+    }
+    public String getClusterDistro() {
+        return clusterDistro;
+    }
+    public String getImageId() {
+        return imageId;
+    }
+    public String getVolumeDriver() {
+        return volumeDriver;
+    }
+    public Boolean isRegistryEnabled() {
+        return registryEnabled;
+    }
+    public String getDockerStorageDriver() {
+        return dockerStorageDriver;
+    }
+    public String getApiserverPort() {
+        return apiserverPort;
+    }
+    public String getName() {
+        return name;
+    }
+    public String getCreatedAt() {
+        return createdAt;
+    }
+    public String getNetworkDriver() {
+        return networkDriver;
+    }
+    public String getFixedNetwork() {
+        return fixedNetwork;
+    }
+    public String getCoe() {
+        return coe;
+    }
+    public String getFlavorId() {
+        return flavorId;
+    }
+    public Boolean isMasterLbEnabled() {
+        return masterLbEnabled;
+    }
+    public String getDnsNameserver() {
+        return dnsNameserver;
+    } 
+    
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues()
+                .add("insecureRegistry", insecureRegistry)
+                .add("links", links)
+                .add("httpProxy", httpProxy)
+                .add("updatedAt", updatedAt)
+                .add("floatingIpEnabled", floatingIpEnabled)
+                .add("fixedSubnet", fixedSubnet)
+                .add("masterFlavorId", masterFlavorId)
+                .add("uuid", uuid)
+                .add("noProxy", noProxy)
+                .add("httpsProxy", httpsProxy)
+                .add("tlsDisabled", tlsDisabled)
+                .add("keypairId", keypairId)
+                .add("publicBaymodel", publicBaymodel)
+                .add("dockerVolumeSize", dockerVolumeSize)
+                .add("serverType", serverType)
+                .add("externalNetworkId", externalNetworkId)
+                .add("clusterDistro", clusterDistro)
+                .add("imageId", imageId)
+                .add("volumeDriver", volumeDriver)
+                .add("registryEnabled", registryEnabled)
+                .add("dockerStorageDriver", dockerStorageDriver)
+                .add("apiserverPort", apiserverPort)
+                .add("name", name)
+                .add("createdAt", createdAt)
+                .add("networkDriver", networkDriver)
+                .add("fixedNetwork", fixedNetwork)
+                .add("coe", coe)
+                .add("flavorId", flavorId)
+                .add("masterLbEnabled", masterLbEnabled)
+                .add("dnsNameserver", dnsNameserver)
+                .toString();
+    }
+    
+    /**
+     * Concrete builder containing MagnumBaymodel as model 
+     *
+     */
+    public static class BaymodelConcreteBuilder implements BaymodelBuilder{
+
+        MagnumBaymodel model;
+        
+        public BaymodelConcreteBuilder() {
+            this(new MagnumBaymodel());
+        }
+        
+        public BaymodelConcreteBuilder(MagnumBaymodel model) {
+            this.model = model;
+        }
+        
+        @Override
+        public Baymodel build() {
+            return model;
+        }
+
+        @Override
+        public BaymodelBuilder from(Baymodel in) {
+            if(in != null)
+                this.model = (MagnumBaymodel)in;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder insecureRegistry(String insecureRegistry) {
+            model.insecureRegistry = insecureRegistry;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder links(List<GenericLink> links) {
+            model.links = links;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder httpProxy(String httpProxy) {
+            model.httpProxy = httpProxy;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder updatedAt(String updatedAt) {
+            model.updatedAt = updatedAt;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder isFloatingIpEnabled(Boolean floatingIpEnabled) {
+            model.floatingIpEnabled = floatingIpEnabled;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder fixedSubnet(String fixedSubnet) {
+            model.fixedSubnet = fixedSubnet;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder masterFlavorId(String masterFlavorId) {
+            model.masterFlavorId = masterFlavorId;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder uuid(String uuid) {
+            model.uuid = uuid;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder noProxy(String noProxy) {
+            model.noProxy = noProxy;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder httpsProxy(String httpsProxy) {
+            model.httpsProxy = httpsProxy;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder tlsDisabled(Boolean tlsDisabled) {
+            model.tlsDisabled = tlsDisabled;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder keypairId(String keypairId) {
+            model.keypairId = keypairId;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder publicBaymodel(Boolean publicBaymodel) {
+            model.publicBaymodel = publicBaymodel;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder dockerVolumeSize(String dockerVolumeSize) {
+            model.dockerVolumeSize = dockerVolumeSize;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder serverType(String serverType) {
+            model.serverType = serverType;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder externalNetworkId(String externalNetworkId) {
+            model.externalNetworkId = externalNetworkId;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder clusterDistro(String clusterDistro) {
+            model.clusterDistro = clusterDistro;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder imageId(String imageId) {
+            model.imageId = imageId;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder volumeDriver(String volumeDriver) {
+            model.volumeDriver = volumeDriver;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder registryEnabled(Boolean registryEnabled) {
+            model.registryEnabled = registryEnabled;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder dockerStorageDriver(String dockerStorageDriver) {
+            model.dockerStorageDriver = dockerStorageDriver;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder apiserverPort(String apiserverPort) {
+            model.apiserverPort = apiserverPort;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder createdAt(String createdAt) {
+            model.createdAt = createdAt;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder networkDriver(String networkDriver) {
+            model.networkDriver = networkDriver;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder fixedNetwork(String fixedNetwork) {
+            model.fixedNetwork = fixedNetwork;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder coe(String coe) {
+            model.coe = coe;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder flavorId(String flavorId) {
+            model.flavorId = flavorId;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder masterLbEnabled(Boolean masterLbEnabled) {
+            model.masterLbEnabled = masterLbEnabled;
+            return this;
+        }
+
+        @Override
+        public BaymodelBuilder dnsNameserver(String dnsNameserver) {
+            model.dnsNameserver = dnsNameserver;
+            return this;
+        }
+        
+    }
+    
+    /**
+     * list of baymodels
+     *
+     *
+     */
+    public static class Baymodels extends ListResult<MagnumBaymodel> {
+        
+        /**
+         * 
+         */
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("baymodels")
+        private List<MagnumBaymodel> list;
+        
+        @Override
+        public List<MagnumBaymodel> value() {
+            return list;
+        }        
+        
+    }
+ 
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumCarequest.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumCarequest.java
@@ -1,0 +1,93 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+import org.openstack4j.model.magnum.Carequest;
+import org.openstack4j.model.magnum.CarequestBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumCarequest implements Carequest {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("bay_uuid")
+    private String bayUuid;
+    @JsonProperty("csr")
+    private String csr;
+    
+    public static CarequestBuilder builder() {
+        return new CarequestConcreteBuilder();
+    }
+
+    @Override
+    public CarequestBuilder toBuilder() {
+        return new CarequestConcreteBuilder(this);
+    }
+
+    public String getBayUuid() {
+        return bayUuid;
+    }
+
+    public String getCsr() {
+        return csr;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("bayUuid", bayUuid).add("csr", csr).toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumCarequest as model
+     *
+     */
+    public static class CarequestConcreteBuilder implements CarequestBuilder {
+        MagnumCarequest model;
+
+        public CarequestConcreteBuilder() {
+            this(new MagnumCarequest());
+        }
+
+        public CarequestConcreteBuilder(MagnumCarequest model) {
+            this.model = model;
+        }
+
+        @Override
+        public Carequest build() {
+            return model;
+        }
+
+        @Override
+        public CarequestBuilder from(Carequest in) {
+            if (in != null)
+                this.model = (MagnumCarequest) in;
+            return this;
+        }
+
+        @Override
+        public CarequestBuilder bayUuid(String bayUuid) {
+            model.bayUuid = bayUuid;
+            return this;
+        }
+
+        @Override
+        public CarequestBuilder csr(String csr) {
+            model.csr = csr;
+            return this;
+        }
+    }
+
+    public static class Carequests extends ListResult<MagnumCarequest> {
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("carequests")
+        private List<MagnumCarequest> list;
+
+        @Override
+        public List<MagnumCarequest> value() {
+            return list;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumCertificate.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumCertificate.java
@@ -1,0 +1,108 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+
+import org.openstack4j.model.magnum.Certificate;
+import org.openstack4j.model.magnum.CertificateBuilder;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumCertificate implements Certificate {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("pem")
+    private String pem;
+    @JsonProperty("bay_uuid")
+    private String bayUuid;
+    @JsonProperty("links")
+    private List<GenericLink> links;
+
+    public static CertificateBuilder builder() {
+        return new CertificateConcreteBuilder();
+    }
+    
+    @Override
+    public CertificateBuilder toBuilder() {
+        return new CertificateConcreteBuilder(this);
+    }
+
+    public String getPem() {
+        return pem;
+    }
+
+    public String getBayUuid() {
+        return bayUuid;
+    }
+
+    public List<GenericLink> getLinks() {
+        return links;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("pem", pem).add("bayUuid", bayUuid).add("links", links)
+                .toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumCertificate as model
+     *
+     */
+    public static class CertificateConcreteBuilder implements CertificateBuilder {
+        MagnumCertificate model;
+
+        public CertificateConcreteBuilder() {
+            this(new MagnumCertificate());
+        }
+
+        public CertificateConcreteBuilder(MagnumCertificate model) {
+            this.model = model;
+        }
+
+        @Override
+        public Certificate build() {
+            return model;
+        }
+
+        @Override
+        public CertificateBuilder from(Certificate in) {
+            if (in != null)
+                this.model = (MagnumCertificate) in;
+            return this;
+        }
+
+        @Override
+        public CertificateBuilder pem(String pem) {
+            model.pem = pem;
+            return this;
+        }
+
+        @Override
+        public CertificateBuilder bayUuid(String bayUuid) {
+            model.bayUuid = bayUuid;
+            return this;
+        }
+
+        @Override
+        public CertificateBuilder links(List<GenericLink> links) {
+            model.links = links;
+            return this;
+        }
+    }
+
+    public static class Certificates extends ListResult<MagnumCertificate> {
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("certificates")
+        private List<MagnumCertificate> list;
+
+        @Override
+        public List<MagnumCertificate> value() {
+            return list;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumCluster.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumCluster.java
@@ -1,0 +1,207 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+
+import org.openstack4j.model.magnum.Cluster;
+import org.openstack4j.model.magnum.ClusterBuilder;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumCluster implements Cluster {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("cluster_template_id")
+    private String clusterTemplateId;
+    @JsonProperty("uuid")
+    private String uuid;
+    @JsonProperty("links")
+    private List<GenericLink> links;
+    @JsonProperty("stack_id")
+    private String stackId;
+    @JsonProperty("master_count")
+    private Integer masterCount;
+    @JsonProperty("create_timeout")
+    private Integer createTimeout;
+    @JsonProperty("node_count")
+    private Integer nodeCount;
+    @JsonProperty("discovery_url")
+    private String discoveryUrl;
+    @JsonProperty("keypair")
+    private String keypair;
+    @JsonProperty("name")
+    private String name;
+
+    public static ClusterBuilder builder() {
+        return new ClusterConcreteBuilder();
+    }
+    
+    @Override
+    public ClusterBuilder toBuilder() {
+        return new ClusterConcreteBuilder(this);
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getClusterTemplateId() {
+        return clusterTemplateId;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public List<GenericLink> getLinks() {
+        return links;
+    }
+
+    public String getStackId() {
+        return stackId;
+    }
+
+    public Integer getMasterCount() {
+        return masterCount;
+    }
+
+    public Integer getCreateTimeout() {
+        return createTimeout;
+    }
+
+    public Integer getNodeCount() {
+        return nodeCount;
+    }
+
+    public String getDiscoveryUrl() {
+        return discoveryUrl;
+    }
+
+    public String getKeypair() {
+        return keypair;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("status", status)
+                .add("clusterTemplateId", clusterTemplateId).add("uuid", uuid).add("links", links)
+                .add("stackId", stackId).add("masterCount", masterCount).add("createTimeout", createTimeout)
+                .add("nodeCount", nodeCount).add("discoveryUrl", discoveryUrl).add("keypair", keypair).add("name", name)
+                .toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumCluster as model
+     *
+     */
+    public static class ClusterConcreteBuilder implements ClusterBuilder {
+        MagnumCluster model;
+
+        public ClusterConcreteBuilder() {
+            this(new MagnumCluster());
+        }
+
+        public ClusterConcreteBuilder(MagnumCluster model) {
+            this.model = model;
+        }
+
+        @Override
+        public Cluster build() {
+            return model;
+        }
+
+        @Override
+        public ClusterBuilder from(Cluster in) {
+            if (in != null)
+                this.model = (MagnumCluster) in;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder status(String status) {
+            model.status = status;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder clusterTemplateId(String clusterTemplateId) {
+            model.clusterTemplateId = clusterTemplateId;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder uuid(String uuid) {
+            model.uuid = uuid;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder links(List<GenericLink> links) {
+            model.links = links;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder stackId(String stackId) {
+            model.stackId = stackId;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder masterCount(Integer masterCount) {
+            model.masterCount = masterCount;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder createTimeout(Integer createTimeout) {
+            model.createTimeout = createTimeout;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder nodeCount(Integer nodeCount) {
+            model.nodeCount = nodeCount;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder discoveryUrl(String discoveryUrl) {
+            model.discoveryUrl = discoveryUrl;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder keypair(String keypair) {
+            model.keypair = keypair;
+            return this;
+        }
+
+        @Override
+        public ClusterBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+    }
+
+    public static class Clusters extends ListResult<MagnumCluster> {
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("clusters")
+        private List<MagnumCluster> list;
+
+        @Override
+        public List<MagnumCluster> value() {
+            return list;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumClustertemplate.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumClustertemplate.java
@@ -1,0 +1,463 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+
+import org.openstack4j.model.magnum.Clustertemplate;
+import org.openstack4j.model.magnum.ClustertemplateBuilder;
+import org.openstack4j.model.magnum.Label;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumClustertemplate implements Clustertemplate {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("insecure_registry")
+    private String insecureRegistry;
+    @JsonProperty("links")
+    private List<GenericLink> links;
+    @JsonProperty("http_proxy")
+    private String httpProxy;
+    @JsonProperty("updated_at")
+    private String updatedAt;
+    @JsonProperty("floating_ip_enabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean floatingIpEnabled;
+    @JsonProperty("fixed_subnet")
+    private String fixedSubnet;
+    @JsonProperty("master_flavor_id")
+    private String masterFlavorId;
+    @JsonProperty("uuid")
+    private String uuid;
+    @JsonProperty("no_proxy")
+    private String noProxy;
+    @JsonProperty("https_proxy")
+    private String httpsProxy;
+    @JsonProperty("tls_disabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean tlsDisabled;
+    @JsonProperty("keypair_id")
+    private String keypairId;
+    @JsonProperty("public_template")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean publicTemplate;
+    @JsonProperty("labels")
+    private Label labels;
+    @JsonProperty("docker_volume_size")
+    private Integer dockerVolumeSize;
+    @JsonProperty("server_type")
+    private String serverType;
+    @JsonProperty("external_network_id")
+    private String externalNetworkId;
+    @JsonProperty("cluster_distro")
+    private String clusterDistro;
+    @JsonProperty("image_id")
+    private String imageId;
+    @JsonProperty("volume_driver")
+    private String volumeDriver;
+    @JsonProperty("registry_enabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean registryEnabled;
+    @JsonProperty("docker_storage_driver")
+    private String dockerStorageDriver;
+    @JsonProperty("apiserver_port")
+    private String apiserverPort;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("created_at")
+    private String createdAt;
+    @JsonProperty("network_driver")
+    private String networkDriver;
+    @JsonProperty("fixed_network")
+    private String fixedNetwork;
+    @JsonProperty("coe")
+    private String coe;
+    @JsonProperty("flavor_id")
+    private String flavorId;
+    @JsonProperty("master_lb_enabled")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean masterLbEnabled;
+    @JsonProperty("dns_nameserver")
+    private String dnsNameserver;
+
+    
+    public static ClustertemplateBuilder builder() {
+        return new ClustertemplateConcreteBuilder();
+    }
+    
+    @Override
+    public ClustertemplateBuilder toBuilder() {
+        return new ClustertemplateConcreteBuilder(this);
+    }
+
+    public String getInsecureRegistry() {
+        return insecureRegistry;
+    }
+
+    public List<GenericLink> getLinks() {
+        return links;
+    }
+
+    public String getHttpProxy() {
+        return httpProxy;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public Boolean getFloatingIpEnabled() {
+        return floatingIpEnabled;
+    }
+
+    public String getFixedSubnet() {
+        return fixedSubnet;
+    }
+
+    public String getMasterFlavorId() {
+        return masterFlavorId;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public String getNoProxy() {
+        return noProxy;
+    }
+
+    public String getHttpsProxy() {
+        return httpsProxy;
+    }
+
+    public Boolean getTlsDisabled() {
+        return tlsDisabled;
+    }
+
+    public String getKeypairId() {
+        return keypairId;
+    }
+
+    public Boolean getPublicTemplate() {
+        return publicTemplate;
+    }
+
+    public Label getLabels() {
+        return labels;
+    }
+
+    public Integer getDockerVolumeSize() {
+        return dockerVolumeSize;
+    }
+
+    public String getServerType() {
+        return serverType;
+    }
+
+    public String getExternalNetworkId() {
+        return externalNetworkId;
+    }
+
+    public String getClusterDistro() {
+        return clusterDistro;
+    }
+
+    public String getImageId() {
+        return imageId;
+    }
+
+    public String getVolumeDriver() {
+        return volumeDriver;
+    }
+
+    public Boolean getRegistryEnabled() {
+        return registryEnabled;
+    }
+
+    public String getDockerStorageDriver() {
+        return dockerStorageDriver;
+    }
+
+    public String getApiserverPort() {
+        return apiserverPort;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getNetworkDriver() {
+        return networkDriver;
+    }
+
+    public String getFixedNetwork() {
+        return fixedNetwork;
+    }
+
+    public String getCoe() {
+        return coe;
+    }
+
+    public String getFlavorId() {
+        return flavorId;
+    }
+
+    public Boolean getMasterLbEnabled() {
+        return masterLbEnabled;
+    }
+
+    public String getDnsNameserver() {
+        return dnsNameserver;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("insecureRegistry", insecureRegistry)
+                .add("links", links).add("httpProxy", httpProxy).add("updatedAt", updatedAt)
+                .add("floatingIpEnabled", floatingIpEnabled).add("fixedSubnet", fixedSubnet)
+                .add("masterFlavorId", masterFlavorId).add("uuid", uuid).add("noProxy", noProxy)
+                .add("httpsProxy", httpsProxy).add("tlsDisabled", tlsDisabled).add("keypairId", keypairId)
+                .add("publicTemplate", publicTemplate).add("labels", labels).add("dockerVolumeSize", dockerVolumeSize)
+                .add("serverType", serverType).add("externalNetworkId", externalNetworkId)
+                .add("clusterDistro", clusterDistro).add("imageId", imageId).add("volumeDriver", volumeDriver)
+                .add("registryEnabled", registryEnabled).add("dockerStorageDriver", dockerStorageDriver)
+                .add("apiserverPort", apiserverPort).add("name", name).add("createdAt", createdAt)
+                .add("networkDriver", networkDriver).add("fixedNetwork", fixedNetwork).add("coe", coe)
+                .add("flavorId", flavorId).add("masterLbEnabled", masterLbEnabled).add("dnsNameserver", dnsNameserver)
+                .toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumClustertemplate as model
+     *
+     */
+    public static class ClustertemplateConcreteBuilder implements ClustertemplateBuilder {
+        MagnumClustertemplate model;
+
+        public ClustertemplateConcreteBuilder() {
+            this(new MagnumClustertemplate());
+        }
+
+        public ClustertemplateConcreteBuilder(MagnumClustertemplate model) {
+            this.model = model;
+        }
+
+        @Override
+        public Clustertemplate build() {
+            return model;
+        }
+
+        @Override
+        public ClustertemplateBuilder from(Clustertemplate in) {
+            if (in != null)
+                this.model = (MagnumClustertemplate) in;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder insecureRegistry(String insecureRegistry) {
+            model.insecureRegistry = insecureRegistry;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder links(List<GenericLink> links) {
+            model.links = links;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder httpProxy(String httpProxy) {
+            model.httpProxy = httpProxy;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder updatedAt(String updatedAt) {
+            model.updatedAt = updatedAt;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder floatingIpEnabled(Boolean floatingIpEnabled) {
+            model.floatingIpEnabled = floatingIpEnabled;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder fixedSubnet(String fixedSubnet) {
+            model.fixedSubnet = fixedSubnet;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder masterFlavorId(String masterFlavorId) {
+            model.masterFlavorId = masterFlavorId;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder uuid(String uuid) {
+            model.uuid = uuid;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder noProxy(String noProxy) {
+            model.noProxy = noProxy;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder httpsProxy(String httpsProxy) {
+            model.httpsProxy = httpsProxy;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder tlsDisabled(Boolean tlsDisabled) {
+            model.tlsDisabled = tlsDisabled;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder keypairId(String keypairId) {
+            model.keypairId = keypairId;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder publicTemplate(Boolean publicTemplate) {
+            model.publicTemplate = publicTemplate;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder labels(Label labels) {
+            model.labels = labels;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder dockerVolumeSize(Integer dockerVolumeSize) {
+            model.dockerVolumeSize = dockerVolumeSize;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder serverType(String serverType) {
+            model.serverType = serverType;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder externalNetworkId(String externalNetworkId) {
+            model.externalNetworkId = externalNetworkId;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder clusterDistro(String clusterDistro) {
+            model.clusterDistro = clusterDistro;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder imageId(String imageId) {
+            model.imageId = imageId;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder volumeDriver(String volumeDriver) {
+            model.volumeDriver = volumeDriver;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder registryEnabled(Boolean registryEnabled) {
+            model.registryEnabled = registryEnabled;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder dockerStorageDriver(String dockerStorageDriver) {
+            model.dockerStorageDriver = dockerStorageDriver;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder apiserverPort(String apiserverPort) {
+            model.apiserverPort = apiserverPort;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder createdAt(String createdAt) {
+            model.createdAt = createdAt;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder networkDriver(String networkDriver) {
+            model.networkDriver = networkDriver;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder fixedNetwork(String fixedNetwork) {
+            model.fixedNetwork = fixedNetwork;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder coe(String coe) {
+            model.coe = coe;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder flavorId(String flavorId) {
+            model.flavorId = flavorId;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder masterLbEnabled(Boolean masterLbEnabled) {
+            model.masterLbEnabled = masterLbEnabled;
+            return this;
+        }
+
+        @Override
+        public ClustertemplateBuilder dnsNameserver(String dnsNameserver) {
+            model.dnsNameserver = dnsNameserver;
+            return this;
+        }
+    }
+
+    public static class Clustertemplates extends ListResult<MagnumClustertemplate> {
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("clustertemplates")
+        private List<MagnumClustertemplate> list;
+
+        @Override
+        public List<MagnumClustertemplate> value() {
+            return list;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumContainer.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumContainer.java
@@ -1,0 +1,181 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+
+import org.openstack4j.model.magnum.Container;
+import org.openstack4j.model.magnum.ContainerBuilder;
+import org.openstack4j.openstack.common.GenericLink;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumContainer implements Container {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("uuid")
+    private String uuid;
+    @JsonProperty("links")
+    private List<GenericLink> links;
+    @JsonProperty("image")
+    private String image;
+    @JsonProperty("environment")
+    private MagnumEnvironment environment;
+    @JsonProperty("command")
+    private String command;
+    @JsonProperty("memory")
+    private String memory;
+    @JsonProperty("bay_uuid")
+    private String bayUuid;
+    @JsonProperty("name")
+    private String name;
+
+    public static ContainerBuilder builder() {
+        return new ContainerConcreteBuilder();
+    }
+    
+    @Override
+    public ContainerBuilder toBuilder() {
+        return new ContainerConcreteBuilder(this);
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public List<GenericLink> getLinks() {
+        return links;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public MagnumEnvironment getEnvironment() {
+        return environment;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public String getMemory() {
+        return memory;
+    }
+
+    public String getBayUuid() {
+        return bayUuid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("status", status).add("uuid", uuid).add("links", links)
+                .add("image", image).add("environment", environment).add("command", command).add("memory", memory)
+                .add("bayUuid", bayUuid).add("name", name).toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumContainer as model
+     *
+     */
+    public static class ContainerConcreteBuilder implements ContainerBuilder {
+        MagnumContainer model;
+
+        public ContainerConcreteBuilder() {
+            this(new MagnumContainer());
+        }
+
+        public ContainerConcreteBuilder(MagnumContainer model) {
+            this.model = model;
+        }
+
+        @Override
+        public Container build() {
+            return model;
+        }
+
+        @Override
+        public ContainerBuilder from(Container in) {
+            if (in != null)
+                this.model = (MagnumContainer) in;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder status(String status) {
+            model.status = status;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder uuid(String uuid) {
+            model.uuid = uuid;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder links(List<GenericLink> links) {
+            model.links = links;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder image(String image) {
+            model.image = image;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder environment(MagnumEnvironment environment) {
+            model.environment = environment;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder command(String command) {
+            model.command = command;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder memory(String memory) {
+            model.memory = memory;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder bayUuid(String bayUuid) {
+            model.bayUuid = bayUuid;
+            return this;
+        }
+
+        @Override
+        public ContainerBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+    }
+
+    public static class Containers extends ListResult<MagnumContainer> {
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("containers")
+        private List<MagnumContainer> list;
+
+        @Override
+        public List<MagnumContainer> value() {
+            return list;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumEnvironment.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumEnvironment.java
@@ -1,0 +1,82 @@
+package org.openstack4j.openstack.magnum;
+
+
+import org.openstack4j.model.magnum.Environment;
+import org.openstack4j.model.magnum.EnvironmentBuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumEnvironment implements Environment {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("PATH")
+    private String path;
+    @JsonProperty("LD_LIBRARY_PATH")
+    private String ldLibraryPath;
+
+    public static EnvironmentBuilder builder() {
+        return new EnvironmentConcreteBuilder();
+    }
+    
+    @Override
+    public EnvironmentBuilder toBuilder() {
+        return new EnvironmentConcreteBuilder(this);
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getLdLibraryPath() {
+        return ldLibraryPath;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("path", path).add("ldLibraryPath", ldLibraryPath)
+                .toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumEnvironment as model
+     *
+     */
+    public static class EnvironmentConcreteBuilder implements EnvironmentBuilder {
+        MagnumEnvironment model;
+
+        public EnvironmentConcreteBuilder() {
+            this(new MagnumEnvironment());
+        }
+
+        public EnvironmentConcreteBuilder(MagnumEnvironment model) {
+            this.model = model;
+        }
+
+        @Override
+        public Environment build() {
+            return model;
+        }
+
+        @Override
+        public EnvironmentBuilder from(Environment in) {
+            if (in != null)
+                this.model = (MagnumEnvironment) in;
+            return this;
+        }
+
+        @Override
+        public EnvironmentBuilder path(String path) {
+            model.path = path;
+            return this;
+        }
+
+        @Override
+        public EnvironmentBuilder ldLibraryPath(String ldLibraryPath) {
+            model.ldLibraryPath = ldLibraryPath;
+            return this;
+        }
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumLabel.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumLabel.java
@@ -1,0 +1,66 @@
+package org.openstack4j.openstack.magnum;
+
+import org.openstack4j.model.magnum.Label;
+import org.openstack4j.model.magnum.LabelBuilder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+public class MagnumLabel implements Label {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("key")
+    private String key;
+
+    public static LabelBuilder builder() {
+        return new LabelConcreteBuilder();
+    }
+    
+    @Override
+    public LabelBuilder toBuilder() {
+        return new LabelConcreteBuilder(this);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("key", key).toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumLabel as model
+     *
+     */
+    public static class LabelConcreteBuilder implements LabelBuilder {
+        MagnumLabel model;
+
+        public LabelConcreteBuilder() {
+            this(new MagnumLabel());
+        }
+
+        public LabelConcreteBuilder(MagnumLabel model) {
+            this.model = model;
+        }
+
+        @Override
+        public Label build() {
+            return model;
+        }
+
+        @Override
+        public LabelBuilder from(Label in) {
+            if (in != null)
+                this.model = (MagnumLabel) in;
+            return this;
+        }
+
+        @Override
+        public LabelBuilder key(String key) {
+            model.key = key;
+            return this;
+        }
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumMservice.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumMservice.java
@@ -1,0 +1,295 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+import org.openstack4j.model.magnum.Mservice;
+import org.openstack4j.model.magnum.MserviceBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.google.common.base.Objects;
+
+@JsonRootName("mservice")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumMservice implements Mservice {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	@JsonProperty
+	private String id;
+	private String binary;
+	@JsonProperty("created_at")
+	private String createdAt;
+	private String state;
+	@JsonProperty("report_count")
+	private int reportCount;
+	@JsonProperty("updated_at")
+	private String updatedAt;
+	private String host;
+	@JsonProperty("disabled_reason")
+	private String disabledReason;
+
+	
+	/**
+	 * Magnum service builder
+	 * 
+	 * @return the Magnum Service builder
+	 */
+	public static MserviceBuilder builder() {
+		return new MserviceConcreteBuilder();
+	}
+	
+	@Override
+	public MserviceBuilder toBuilder() {
+		return new MserviceConcreteBuilder(this);
+	}
+	
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	/** 
+	 * Set the id
+	 * 
+	 * @param id
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getBinary() {
+		return binary;
+	}
+
+	/** 
+	 * Set the binary
+	 * 
+	 * @param binary
+	 */
+	public void setBinary(String binary) {
+		this.binary = binary;
+	}
+
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getCreatedAt() {
+		return createdAt;
+	}
+
+	/**
+	 * Set the creation date
+	 * 
+	 * @param createdAt
+	 */
+	public void setCreatedAt(String createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getState() {
+		return state;
+	}
+
+	/**
+	 * Set the state
+	 * 
+	 * @param state
+	 */
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public int getReportCount() {
+		return reportCount;
+	}
+
+	/**
+	 * Set the report count
+	 * 
+	 * @param reportCount
+	 */
+	public void setReportCount(int reportCount) {
+		this.reportCount = reportCount;
+	}
+
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getUpdatedAt() {
+		return updatedAt;
+	}
+
+	/**
+	 * Set the updated time
+	 * 
+	 * @param updatedAt
+	 */
+	public void setUpdatedAt(String updatedAt) {
+		this.updatedAt = updatedAt;
+	}
+
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getHost() {
+		return host;
+	}
+
+	/**
+	 * Set the hostname
+	 * 
+	 * @param host
+	 */
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getDisabledReason() {
+		return disabledReason;
+	}
+	
+
+	/**
+	 * Set the disabled reason
+	 * 
+	 * @param disabledReason
+	 */
+	public void setDisabledReason(String disabledReason) {
+		this.disabledReason = disabledReason;
+	}
+
+	@Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues()
+                .add("id", id)
+                .add("binary", binary)
+                .add("createdAt", createdAt)
+                .add("state", state)
+                .add("reportCount", reportCount)
+                .add("updatedAt", updatedAt)
+                .add("host", host)
+                .add("disabledReason", disabledReason)
+                .toString();
+    }
+
+	/**
+	 * Concrete builder	containing MagnumMservice as model 
+	 *
+	 */
+	public static class MserviceConcreteBuilder implements MserviceBuilder {
+		MagnumMservice model;
+
+		public MserviceConcreteBuilder() {
+			this(new MagnumMservice());
+		}
+
+		MserviceConcreteBuilder(MagnumMservice model) {
+			this.model = model;
+		}
+
+		@Override
+		public Mservice build() {
+			return model;
+		}
+
+		@Override
+		public MserviceBuilder from(Mservice in) {
+			if (in != null)
+				this.model = (MagnumMservice) in;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder id(String id) {
+			model.id = id;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder binary(String binary) {
+			model.binary = binary;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder createdAt(String createdAt) {
+			model.createdAt = createdAt;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder state(String state) {
+			model.state = state;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder reportCount(int reportCount) {
+			model.reportCount = reportCount;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder updatedAt(String updatedAt) {
+			model.updatedAt = updatedAt;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder host(String host) {
+			model.host = host;
+			return this;
+		}
+
+		@Override
+		public MserviceBuilder disabledReason(String disabledReason) {
+			model.disabledReason = disabledReason;
+			return this;
+		}
+
+	}
+
+	/**
+	 * List of Magnum Services 
+	 *
+	 */
+	public static class Mservices extends ListResult<MagnumMservice> {
+
+		private static final long serialVersionUID = 1L;
+		@JsonProperty("mservices")
+		protected List<MagnumMservice> list;
+
+		@Override
+		protected List<MagnumMservice> value() {
+			return list;
+		}
+
+	}
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/MagnumPod.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/MagnumPod.java
@@ -1,0 +1,168 @@
+package org.openstack4j.openstack.magnum;
+
+import java.util.List;
+
+import org.openstack4j.model.magnum.Label;
+import org.openstack4j.model.magnum.Pod;
+import org.openstack4j.model.magnum.PodBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MagnumPod implements Pod {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("uuid")
+    private String uuid;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("desc")
+    private String desc;
+    @JsonProperty("bay_uuid")
+    private String bayUuid;
+    @JsonProperty("images")
+    private List<String> images;
+    @JsonProperty("labels")
+    private Label labels;
+    @JsonProperty("status")
+    private String status;
+
+    public static PodBuilder builder() {
+        return new PodConcreteBuilder();
+    }
+    
+    @Override
+    public PodBuilder toBuilder() {
+        return new PodConcreteBuilder(this);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public String getBayUuid() {
+        return bayUuid;
+    }
+
+    public List<String> getImages() {
+        return images;
+    }
+
+    public Label getLabels() {
+        return labels;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues().add("id", id).add("uuid", uuid).add("name", name)
+                .add("desc", desc).add("bayUuid", bayUuid).add("images", images).add("labels", labels)
+                .add("status", status).toString();
+    }
+
+    /**
+     * Concrete builder containing MagnumPod as model
+     *
+     */
+    public static class PodConcreteBuilder implements PodBuilder {
+        MagnumPod model;
+
+        public PodConcreteBuilder() {
+            this(new MagnumPod());
+        }
+
+        public PodConcreteBuilder(MagnumPod model) {
+            this.model = model;
+        }
+
+        @Override
+        public Pod build() {
+            return model;
+        }
+
+        @Override
+        public PodBuilder from(Pod in) {
+            if (in != null)
+                this.model = (MagnumPod) in;
+            return this;
+        }
+
+        @Override
+        public PodBuilder id(String id) {
+            model.id = id;
+            return this;
+        }
+
+        @Override
+        public PodBuilder uuid(String uuid) {
+            model.uuid = uuid;
+            return this;
+        }
+
+        @Override
+        public PodBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+
+        @Override
+        public PodBuilder desc(String desc) {
+            model.desc = desc;
+            return this;
+        }
+
+        @Override
+        public PodBuilder bayUuid(String bayUuid) {
+            model.bayUuid = bayUuid;
+            return this;
+        }
+
+        @Override
+        public PodBuilder images(List<String> images) {
+            model.images = images;
+            return this;
+        }
+
+        @Override
+        public PodBuilder labels(Label labels) {
+            model.labels = labels;
+            return this;
+        }
+
+        @Override
+        public PodBuilder status(String status) {
+            model.status = status;
+            return this;
+        }
+    }
+
+    public static class Pods extends ListResult<MagnumPod> {
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("pods")
+        private List<MagnumPod> list;
+
+        @Override
+        public List<MagnumPod> value() {
+            return list;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/magnum/internal/MagnumServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/magnum/internal/MagnumServiceImpl.java
@@ -1,0 +1,299 @@
+package org.openstack4j.openstack.magnum.internal;
+
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.openstack4j.core.transport.ClientConstants.*;
+
+
+import org.openstack4j.api.types.ServiceType;
+
+
+import java.util.List;
+
+import org.openstack4j.api.magnum.MagnumService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.magnum.Bay;
+import org.openstack4j.model.magnum.Baymodel;
+import org.openstack4j.model.magnum.Carequest;
+import org.openstack4j.model.magnum.Certificate;
+import org.openstack4j.model.magnum.Cluster;
+import org.openstack4j.model.magnum.Clustertemplate;
+import org.openstack4j.model.magnum.Container;
+import org.openstack4j.model.magnum.Mservice;
+import org.openstack4j.model.magnum.Pod;
+import org.openstack4j.openstack.internal.BaseOpenStackService;
+import org.openstack4j.openstack.magnum.MagnumBay;
+import org.openstack4j.openstack.magnum.MagnumBay.BayConcreteBuilder.Bays;
+import org.openstack4j.openstack.magnum.MagnumBaymodel;
+import org.openstack4j.openstack.magnum.MagnumBaymodel.Baymodels;
+import org.openstack4j.openstack.magnum.MagnumCertificate;
+import org.openstack4j.openstack.magnum.MagnumCluster.Clusters;
+import org.openstack4j.openstack.magnum.MagnumClustertemplate.Clustertemplates;
+import org.openstack4j.openstack.magnum.MagnumContainer;
+import org.openstack4j.openstack.magnum.MagnumContainer.Containers;
+import org.openstack4j.openstack.magnum.MagnumMservice.Mservices;
+import org.openstack4j.openstack.magnum.MagnumPod.Pods;
+
+
+/**
+ * OpenStack Container Infrastructure Management service (Magnum) APIs
+ * 
+ * @author Sohan Sangwan
+ *
+ */
+public class MagnumServiceImpl extends BaseOpenStackService implements MagnumService {
+
+    /**
+     * Lists Magnum Services
+     */
+    @Override
+    public List<? extends Mservice> listMservices() {
+        return get(Mservices.class, uri(MAGNUM_MSERVICES)).serviceType(ServiceType.MAGNUM).execute().getList();
+    }
+
+    @Override
+    public List<? extends Baymodel> listBaymodels() {
+        return get(Baymodels.class, uri(MAGNUM_BAYMODELS)).serviceType(ServiceType.MAGNUM).execute().getList();
+    }
+
+    @Override
+    public Baymodel createBaymodel(Baymodel baymodel) {
+        checkNotNull(baymodel);
+        return post(MagnumBaymodel.class, MAGNUM_BAYMODELS).serviceType(ServiceType.MAGNUM).entity(baymodel).execute();
+    }
+
+    @Override
+    public ActionResponse deleteBaymodel(String id) {
+        checkNotNull(id);
+        return deleteWithResponse(MAGNUM_BAYMODELS, "/", id).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public Baymodel showBaymodel(String id) {
+        checkNotNull(id);
+        return get(MagnumBaymodel.class, MAGNUM_BAYMODELS, "/", id).serviceType(ServiceType.MAGNUM).execute();
+    }
+    
+    @Override
+    public Baymodel updateBaymodel(String id, String operations) {
+        checkNotNull(id);       
+        checkNotNull(operations);
+        return patch(MagnumBaymodel.class, MAGNUM_BAYMODELS, "/", id).serviceType(ServiceType.MAGNUM).json(operations).execute();        
+    }
+
+    @Override
+    public List<? extends Bay> listBays() {
+        return get(Bays.class, uri(MAGNUM_BAYS)).serviceType(ServiceType.MAGNUM).execute().getList();
+    }
+
+    @Override
+    public Bay createBay(Bay bay) {
+        checkNotNull(bay);
+        return post(MagnumBay.class, MAGNUM_BAYS).serviceType(ServiceType.MAGNUM).entity(bay).execute();
+    }
+
+    @Override
+    public ActionResponse deleteBay(String id) {
+        checkNotNull(id);
+        return deleteWithResponse(MAGNUM_BAYS, "/", id).serviceType(ServiceType.MAGNUM).execute();
+    }
+    
+    @Override
+    public Bay showBay(String id) {
+        checkNotNull(id);
+        return get(MagnumBay.class, MAGNUM_BAYS, "/", id).serviceType(ServiceType.MAGNUM).execute();
+    }
+    
+    @Override
+    public Bay updateBay(String id, String operations) {
+        checkNotNull(id);       
+        checkNotNull(operations);
+        return patch(MagnumBay.class, MAGNUM_BAYS, "/", id).serviceType(ServiceType.MAGNUM).json(operations).execute();        
+    }
+
+    //Containers
+    @Override
+    public List<? extends Container> listContainers() {
+        return get(Containers.class, uri(MAGNUM_CONTAINERS)).serviceType(ServiceType.MAGNUM).execute().getList();
+    }
+    
+    @Override
+    public Container createContainer(Container container) {
+        checkNotNull(container);
+        return post(MagnumContainer.class, MAGNUM_CONTAINERS).serviceType(ServiceType.MAGNUM).entity(container).execute();
+    }
+    
+    @Override
+    public ActionResponse deleteContainer(String uuid) {
+        checkNotNull(uuid);
+        return deleteWithResponse(MAGNUM_CONTAINERS, "/", uuid).serviceType(ServiceType.MAGNUM).execute();
+    }
+    
+    @Override
+    public String execCmdInContainer(String id, String cmd) {
+        checkNotNull(id);
+        checkNotNull(cmd);
+        ///v1/containers/%s/execute?command=ls
+        return put(String.class, uri("%s/execute?command=%s", MAGNUM_CONTAINERS, id, cmd)).serviceType(ServiceType.MAGNUM).execute();
+ 
+    }
+    
+    @Override
+    public String getContainerLogs(String id) {
+        checkNotNull(id);
+        return get(String.class, uri("%s/%s/logs", MAGNUM_CONTAINERS, id)).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public Container pauseContainer(String id) {
+        checkNotNull(id);
+        return put(Container.class, uri("%s/%s/pause", MAGNUM_CONTAINERS, id)).serviceType(ServiceType.MAGNUM).execute();
+    }
+    
+    @Override
+    public Container unpauseContainer(String id) {
+        checkNotNull(id);
+        return put(Container.class, uri("%s/%s/unpause", MAGNUM_CONTAINERS, id)).serviceType(ServiceType.MAGNUM).execute();
+    }
+    
+    @Override
+    public Container rebootContainer(String id) {
+        checkNotNull(id);
+        return put(Container.class, uri("%s/%s/reboot", MAGNUM_CONTAINERS, id)).serviceType(ServiceType.MAGNUM).execute();  
+    }
+    
+    @Override
+    public Container startContainer(String id) {
+        checkNotNull(id);
+        return put(Container.class, uri("%s/%s/start", MAGNUM_CONTAINERS, id)).serviceType(ServiceType.MAGNUM).execute();  
+    }
+    
+    @Override
+    public Container stopContainer(String id) {
+        checkNotNull(id);
+        return put(Container.class, uri("%s/%s/stop", MAGNUM_CONTAINERS, id)).serviceType(ServiceType.MAGNUM).execute();  
+    }
+    
+    @Override
+    public Container showContainer(String id) {
+        checkNotNull(id);
+        return get(Container.class, uri("%s/%s", MAGNUM_CONTAINERS, id)).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public Certificate getCertificate(String uuid) {
+        checkNotNull(uuid);
+        return get(MagnumCertificate.class, uri("%s/%s", MAGNUM_CERTIFICATES, uuid)).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public Certificate signCertificate(Carequest ca) {
+        checkNotNull(ca);
+        return post(MagnumCertificate.class, MAGNUM_CERTIFICATES).serviceType(ServiceType.MAGNUM).entity(ca).execute();        
+    }
+
+    @Override
+    public ActionResponse rotateCertificate(String uuid) {
+        checkNotNull(uuid);
+        return patch(ActionResponse.class, uri("%s/%s", MAGNUM_CERTIFICATES, uuid)).serviceType(ServiceType.MAGNUM).execute();
+    }
+    
+    //Clusters
+
+    @Override
+    public Cluster createCluster(Cluster cluster) {
+        checkNotNull(cluster);
+        return post(Cluster.class, MAGNUM_CLUSTERS).serviceType(ServiceType.MAGNUM).entity(cluster).execute();        
+    }
+
+    @Override
+    public List<? extends Cluster> listClusters() {
+        return get(Clusters.class, uri(MAGNUM_CLUSTERS)).serviceType(ServiceType.MAGNUM).execute().getList();
+    }
+
+    @Override
+    public Cluster showCluster(String id) {
+        checkNotNull(id);
+        return get(Cluster.class, uri("%s/%s", MAGNUM_CLUSTERS, id)).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public ActionResponse deleteCluster(String id) {
+        checkNotNull(id);
+        return deleteWithResponse(MAGNUM_CLUSTERS, "/", id).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public Cluster updateCluster(String id, String operations) {
+        checkNotNull(id);       
+        checkNotNull(operations);
+        return patch(Cluster.class, MAGNUM_CLUSTERS, "/", id).serviceType(ServiceType.MAGNUM).json(operations).execute();        
+    }
+    
+    //Cluster template APIs
+
+    @Override
+    public Clustertemplate createClustertemplate(Clustertemplate template) {
+        checkNotNull(template);
+        return post(Clustertemplate.class, MAGNUM_CLUSTERTEMPLATES).serviceType(ServiceType.MAGNUM).entity(template).execute();  
+    }
+
+    @Override
+    public List<? extends Clustertemplate> listClustertemplate() {
+        return get(Clustertemplates.class, uri(MAGNUM_CLUSTERTEMPLATES)).serviceType(ServiceType.MAGNUM).execute().getList();
+    }
+
+    @Override
+    public ActionResponse deleteClustertemplate(String id) {
+        checkNotNull(id);
+        return deleteWithResponse(MAGNUM_CLUSTERTEMPLATES, "/", id).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public Clustertemplate updateClustertemplate(String id, String operations) {
+        checkNotNull(id);       
+        checkNotNull(operations);
+        return patch(Clustertemplate.class, MAGNUM_CLUSTERTEMPLATES, "/", id).serviceType(ServiceType.MAGNUM).json(operations).execute();        
+    }
+
+    @Override
+    public List<? extends Pod> listPods(String bayUuid) {
+        checkNotNull(bayUuid);
+        // url: '/v1/pods/?bay_ident=%s'
+        return get(Pods.class, uri("%s/?bay_ident=%s", MAGNUM_PODS, bayUuid)).serviceType(ServiceType.MAGNUM).execute().getList();
+    }
+
+    @Override
+    public Pod createPod(Pod pod) {
+        checkNotNull(pod);
+        return post(Pod.class, MAGNUM_PODS).serviceType(ServiceType.MAGNUM).entity(pod).execute();  
+    }
+
+    @Override
+    public ActionResponse deletePod(String bayUuid, String id) {
+        checkNotNull(bayUuid);
+        checkNotNull(id);
+        
+        // Url: '/v1/pods/%s/?bay_ident=%s'
+        return deleteWithResponse( uri("%s/%s/?bay_ident=%s", MAGNUM_PODS, id, bayUuid)).serviceType(ServiceType.MAGNUM).execute();
+    }
+
+    @Override
+    public Pod showPod(String bayUuid, String id) {
+        checkNotNull(bayUuid);   
+        checkNotNull(id);
+        
+        // Url: '/v1/pods/%s/?bay_ident=%s'
+        return get(Pod.class, uri("%s/?bay_ident=%s", MAGNUM_PODS, bayUuid)).serviceType(ServiceType.MAGNUM).execute();        
+    }
+
+    @Override
+    public Pod updatePod(String bayUuid, String id, String operations) {
+        checkNotNull(id);       
+        checkNotNull(operations);
+        return patch(Pod.class, MAGNUM_PODS, "/", id).serviceType(ServiceType.MAGNUM).json(operations).execute();        
+    }
+
+
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
+++ b/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
@@ -63,6 +63,7 @@ import org.openstack4j.api.identity.v3.TokenService;
 import org.openstack4j.api.identity.v3.UserService;
 import org.openstack4j.api.image.ImageService;
 import org.openstack4j.api.image.v2.TaskService;
+import org.openstack4j.api.magnum.MagnumService;
 import org.openstack4j.api.manila.SchedulerStatsService;
 import org.openstack4j.api.manila.SecurityServiceService;
 import org.openstack4j.api.manila.ShareInstanceService;
@@ -209,6 +210,7 @@ import org.openstack4j.openstack.identity.v3.internal.TokenServiceImpl;
 import org.openstack4j.openstack.identity.v3.internal.UserServiceImpl;
 import org.openstack4j.openstack.image.internal.ImageServiceImpl;
 import org.openstack4j.openstack.image.v2.internal.TaskServiceImpl;
+import org.openstack4j.openstack.magnum.internal.MagnumServiceImpl;
 import org.openstack4j.openstack.manila.internal.SchedulerStatsServiceImpl;
 import org.openstack4j.openstack.manila.internal.SecurityServiceServiceImpl;
 import org.openstack4j.openstack.manila.internal.ShareInstanceServiceImpl;
@@ -476,6 +478,7 @@ public class DefaultAPIProvider implements APIProvider {
         bind(TelemetryAodhService.class,TelemetryAodhServiceImpl.class);
         bind(AlarmAodhService.class, AlarmAodhServiceImpl.class);
         bind(ServicesService.class, ServicesServiceImpl.class);
+        bind(MagnumService.class, MagnumServiceImpl.class);
     }
 
     /**


### PR DESCRIPTION
Extended OS4J library to support OpenStack Magnum Service. Implemented following APIs in first commit:
 - list magnum services.
 - list baymodels
 - create baymodel
 - delete baymodel 
 - show baymodel 
 - update baymodel
 - list bays
 - create bay
 - delete bay
 - show bay
 - update bay
 - list containers
 - create container
 - delete container
 - execute a command in a container
 - get container logs
 - pause container
 - unpause container
 - reboot container
 - start container
 - stop container
 - show container
 - get certificate
 - sign certificate
 - rotate certificate
 - create cluster
 - list cluster
 - show cluster
 - delete cluster
 - update cluster
 - create cluster template
 - list cluster templates
 - delete cluster template
 - update cluster template
 - list pods
 - create pod
 - delete pod
 - show pod
 - update pod


  