### PR TITLE
support ipv6 properties in subnet again

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/SubnetTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/SubnetTests.java
@@ -14,22 +14,23 @@ import org.testng.annotations.Test;
  * 
  * @author Taemin 
  */
-@Test(suiteName = "Subnet")
+@Test(suiteName = "subnet")
 public class SubnetTests extends AbstractTest {
 
-    private static final String JSON_SUBNET = "/network/subnet_ipv6.json";      
-    private static final String SUBNET_NAME = "sub1";
-    private static final String SUBNET_ID = "3b80198d-4f7b-4f77-9ef5-774d54e17126";
-
-    @Test
-    public void getSubnet() throws Exception {
-        respondWith(JSON_SUBNET);
-        Subnet n = osv3().networking().subnet().get(SUBNET_ID);
-        server.takeRequest();	 
-        assertEquals(n.getName(), SUBNET_NAME);
-        assertEquals(n.getIpv6AddressMode(), Ipv6AddressMode.DHCPV6_STATEFUL.name());
-        assertEquals(n.getIpv6RaMode(), Ipv6RaMode.DHCPV6_STATEFUL.name());        
-    }
+	private static final String JSON_GET_SUBNET = "/network/subnet_ipv6.json";  
+	
+	private static final String SUBNET_NAME = "sub1";
+	private static final String SUBNET_ID = "3b80198d-4f7b-4f77-9ef5-774d54e17126";	
+	
+	@Test
+	public void getSubnetIpV6() throws Exception {		
+		respondWith(JSON_GET_SUBNET);		 
+		Subnet n = osv3().networking().subnet().get(SUBNET_ID);
+		server.takeRequest();
+		assertEquals(n.getName(), SUBNET_NAME);
+		assertEquals(n.getIpv6AddressMode(), Ipv6AddressMode.DHCPV6_STATEFUL);
+		assertEquals(n.getIpv6RaMode(), Ipv6RaMode.DHCPV6_STATEFUL);
+	}
 
     @Override
     protected Service service() {

--- a/core-test/src/main/java/org/openstack4j/api/network/SubnetTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/SubnetTests.java
@@ -1,0 +1,39 @@
+package org.openstack4j.api.network;
+
+import static org.testng.Assert.assertEquals;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.model.network.Ipv6AddressMode;
+import org.openstack4j.model.network.Ipv6RaMode;
+import org.openstack4j.model.network.Subnet;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the Neutron -> Subnet API against the mock webserver and spec based
+ * json responses
+ * 
+ * @author Taemin 
+ */
+@Test(suiteName = "Subnet")
+public class SubnetTests extends AbstractTest {
+
+    private static final String JSON_SUBNET = "/network/subnet_ipv6.json";      
+    private static final String SUBNET_NAME = "sub1";
+    private static final String SUBNET_ID = "3b80198d-4f7b-4f77-9ef5-774d54e17126";
+
+    @Test
+    public void getSubnet() throws Exception {
+        respondWith(JSON_SUBNET);
+        Subnet n = osv3().networking().subnet().get(SUBNET_ID);
+        server.takeRequest();	 
+        assertEquals(n.getName(), SUBNET_NAME);
+        assertEquals(n.getIpv6AddressMode(), Ipv6AddressMode.DHCPV6_STATEFUL.name());
+        assertEquals(n.getIpv6RaMode(), Ipv6RaMode.DHCPV6_STATEFUL.name());        
+    }
+
+    @Override
+    protected Service service() {
+        return Service.NETWORK;
+    }
+    
+}

--- a/core-test/src/main/resources/network/subnet_ipv6.json
+++ b/core-test/src/main/resources/network/subnet_ipv6.json
@@ -1,0 +1,30 @@
+{
+    "subnet": {
+        "name": "sub1",
+        "enable_dhcp": true,
+        "network_id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "segment_id": null,
+        "project_id": "4fd44f30292945e481c7b8a0c8908869",
+        "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+        "dns_nameservers": [],
+        "allocation_pools": [
+            {
+                "start": "2620:0:2d0:200::2",
+                "end": "2620:0:2d0:200:ffff:ffff:ffff:fffe"
+            }
+        ],
+        "host_routes": [],
+        "ip_version": 6,
+        "gateway_ip": "2620:0:2d0:200::1",
+        "cidr": "2620:0:2d0:200::/64",
+        "id": "3b80198d-4f7b-4f77-9ef5-774d54e17126",
+        "created_at": "2016-10-10T14:35:47Z",
+        "description": "",
+        "ipv6_address_mode": "dhcpv6-stateful",
+        "ipv6_ra_mode": "dhcpv6-stateful",
+        "revision_number": 2,
+        "service_types": [],
+        "subnetpool_id": null,
+        "updated_at": "2016-10-10T14:35:47Z"
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/network/Ipv6AddressMode.java
+++ b/core/src/main/java/org/openstack4j/model/network/Ipv6AddressMode.java
@@ -1,0 +1,38 @@
+package org.openstack4j.model.network;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The IPv6 address modes specifies mechanisms for assigning IP addresses
+ * 
+ * @author Taemin
+ */
+public enum Ipv6AddressMode {
+	SLAAC("slaac"),	
+	DHCPV6_STATEFUL("dhcpv6-stateful"),	
+	DHCPV6_STATELESS("dhcpv6-stateless"),
+	NULL("null");
+	
+	private final String ipv6AddressMode;
+	
+	private Ipv6AddressMode(String ipv6AddressMode) {
+		this.ipv6AddressMode = ipv6AddressMode;
+	}
+	
+	@JsonValue
+	public String getIpv6AddressMode() {
+		return ipv6AddressMode;
+	}
+	
+	@JsonCreator
+	public static Ipv6AddressMode forValue(String value) {
+		if (value != null){
+			for (Ipv6AddressMode s : Ipv6AddressMode.values()) {
+				if (s.ipv6AddressMode.equalsIgnoreCase(value))
+					return s;
+			}
+		}
+		return null;
+	}	
+}

--- a/core/src/main/java/org/openstack4j/model/network/Ipv6RaMode.java
+++ b/core/src/main/java/org/openstack4j/model/network/Ipv6RaMode.java
@@ -1,0 +1,37 @@
+package org.openstack4j.model.network;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The IPv6 router advertisement specifies whether the networking service should transmit ICMPv6 packets, for a subnet
+ * 
+ * @author Taemin
+ */
+public enum Ipv6RaMode {
+	SLAAC("slaac"),	
+	DHCPV6_STATEFUL("dhcpv6-stateful"),	
+	DHCPV6_STATELESS("dhcpv6-stateless");
+	
+	private final String ipv6RaMode;
+	
+	private Ipv6RaMode(String ipv6RaMode) {
+		this.ipv6RaMode = ipv6RaMode;
+	}
+	
+	@JsonValue
+	public String getIpv6RaMode() {
+		return ipv6RaMode;
+	}
+
+	@JsonCreator
+	public static Ipv6RaMode forValue(String value) {
+		if (value != null) {
+			for (Ipv6RaMode v : Ipv6RaMode.values()) {
+				if (v.ipv6RaMode.equalsIgnoreCase(value))
+					return v;
+			}		
+		}
+		return null;
+	}
+}

--- a/core/src/main/java/org/openstack4j/model/network/Subnet.java
+++ b/core/src/main/java/org/openstack4j/model/network/Subnet.java
@@ -54,4 +54,14 @@ public interface Subnet extends Resource, Buildable<SubnetBuilder> {
 	 * @return the cidr representing the IP range for this subnet, based on IP version
 	 */
 	String getCidr();
+	
+	/**
+	 * @return The IPv6 address modes specifies mechanisms for assigning IP addresses
+	 */
+	Ipv6AddressMode getIpv6AddressMode();
+	
+	/**
+	 * @return the IPv6 router advertisement specifies whether the networking service should transmit ICMPv6 packets, for a subnet
+	 */
+	Ipv6RaMode getIpv6RaMode();		
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/SubnetBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/SubnetBuilder.java
@@ -3,6 +3,8 @@ package org.openstack4j.model.network.builder;
 import org.openstack4j.common.Buildable.Builder;
 import org.openstack4j.model.identity.v3.Tenant;
 import org.openstack4j.model.network.IPVersionType;
+import org.openstack4j.model.network.Ipv6AddressMode;
+import org.openstack4j.model.network.Ipv6RaMode;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.network.Subnet;
 
@@ -85,5 +87,14 @@ public interface SubnetBuilder extends Builder<SubnetBuilder, Subnet> {
 	 * @returnSubnetBuilder
 	 */
 	SubnetBuilder addHostRoute(String destination, String nexthop);
-
+	
+    /**
+     * @see Subnet#getIpv6AddressMode()
+     */
+	SubnetBuilder ipv6AddressMode (Ipv6AddressMode ipv6AddressMode);
+	
+    /**
+     * @see Subnet#getIpv6RaMode()
+     */
+	SubnetBuilder ipv6RaMode(Ipv6RaMode ipv6RaMode);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSubnet.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSubnet.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import org.openstack4j.model.common.builder.ResourceBuilder;
 import org.openstack4j.model.network.HostRoute;
 import org.openstack4j.model.network.IPVersionType;
+import org.openstack4j.model.network.Ipv6AddressMode;
+import org.openstack4j.model.network.Ipv6RaMode;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.network.Pool;
 import org.openstack4j.model.network.Subnet;
@@ -51,13 +53,17 @@ public class NeutronSubnet implements Subnet {
 	@JsonProperty("gateway_ip")
 	private String gateway;
 	private String cidr;
+	@JsonProperty("ipv6_address_mode")
+	private Ipv6AddressMode ipv6AddressMode;
+	@JsonProperty("ipv6_ra_mode")
+	private Ipv6RaMode ipv6RaMode;
 
     public NeutronSubnet() {
     }
 
     public NeutronSubnet(String id, String name, boolean enableDHCP, String networkId, String tenantId, List<String> dnsNames,
                          List<NeutronPool> pools, List<NeutronHostRoute> hostRoutes, IPVersionType ipVersion,
-                         String gateway, String cidr) {
+                         String gateway, String cidr, Ipv6AddressMode ipv6AddressMode, Ipv6RaMode ipv6RaMode) {
         this.id = id;
         this.name = name;
         this.enableDHCP = enableDHCP;
@@ -69,6 +75,8 @@ public class NeutronSubnet implements Subnet {
         this.ipVersion = ipVersion;
         this.gateway = gateway;
         this.cidr = cidr;
+        this.ipv6AddressMode = ipv6AddressMode;
+        this.ipv6RaMode = ipv6RaMode;
     }
 
     public static SubnetBuilder builder() {
@@ -193,6 +201,22 @@ public class NeutronSubnet implements Subnet {
 	public String getCidr() {
 		return cidr;
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Ipv6AddressMode getIpv6AddressMode() {
+		return ipv6AddressMode;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Ipv6RaMode getIpv6RaMode() {
+		return ipv6RaMode;
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -203,6 +227,7 @@ public class NeutronSubnet implements Subnet {
 				.add("id", id).add("name", name).add("enableDHCP", enableDHCP).add("network-id", networkId)
 				.add("tenant_id", tenantId).add("dns_nameservers", dnsNames).add("allocation_pools", pools)
 				.add("host_routes", hostRoutes).add("ip_version", ipVersion).add("gateway_ip", gateway).add("cidr", cidr)
+				.add("ipv6AddressMode", ipv6AddressMode).add("ipv6RaMode", ipv6RaMode)
 				.toString();
 	}
 
@@ -216,8 +241,8 @@ public class NeutronSubnet implements Subnet {
 
         public NeutronSubnetNoGateway(String id, String name, boolean enableDHCP, String networkId, String tenantId,
                                       List<String> dnsNames, List<NeutronPool> pools, List<NeutronHostRoute> hostRoutes,
-                                      IPVersionType ipVersion, String cidr) {
-            super(id, name, enableDHCP, networkId, tenantId, dnsNames, pools, hostRoutes, ipVersion, null, cidr);
+                                      IPVersionType ipVersion, String cidr, Ipv6AddressMode ipv6AddressMode, Ipv6RaMode ipv6RaMode) {
+            super(id, name, enableDHCP, networkId, tenantId, dnsNames, pools, hostRoutes, ipVersion, null, cidr, ipv6AddressMode, ipv6RaMode);
             this.gateway = null;
         }
     }
@@ -297,12 +322,24 @@ public class NeutronSubnet implements Subnet {
 		  isNoGateway = true;
 		  return this;
 		}
+	
+		@Override
+		public SubnetBuilder ipv6AddressMode(Ipv6AddressMode ipv6AddressMode) {
+			m.ipv6AddressMode = ipv6AddressMode;
+			return this;
+		}
+		
+		@Override
+		public SubnetBuilder ipv6RaMode(Ipv6RaMode ipv6RaMode) {
+			m.ipv6RaMode = ipv6RaMode;
+			return this;
+		}
 
 		@Override
 		public Subnet build() {
             if(isNoGateway) {
                 return new NeutronSubnetNoGateway(m.id, m.name, m.enableDHCP, m.networkId,
-                m.tenantId, m.dnsNames, m.pools, m.hostRoutes, m.ipVersion, m.cidr);
+                m.tenantId, m.dnsNames, m.pools, m.hostRoutes, m.ipVersion, m.cidr, m.ipv6AddressMode, m.ipv6RaMode);
             }
             return m;
 		}
@@ -338,7 +375,5 @@ public class NeutronSubnet implements Subnet {
             m.hostRoutes.add(new NeutronHostRoute(destination, nexthop));
             return this;
         }
-
 	}
-	
 }


### PR DESCRIPTION
Hi @auhlig 
I couldn't find subnet ipv6 properties in the lastest snapshot.
I don't know what is wrong.
Could you check it again?
Once, I created PR again. 

ipv6_address_mode
: The IPv6 address modes specifies mechanisms for assigning IP
addresses. Value is slaac, dhcpv6-stateful, dhcpv6-stateless or null.
ipv6_ra_mode
: The IPv6 router advertisement specifies whether the networking service
should transmit ICMPv6 packets, for a subnet. Value is slaac,
dhcpv6-stateful, dhcpv6-stateless or null.