### PR TITLE
Allow passing additional properties for Glance V2

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/image/v2/ImageV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/image/v2/ImageV2Tests.java
@@ -2,6 +2,7 @@ package org.openstack4j.api.image.v2;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -80,6 +81,12 @@ public class ImageV2Tests extends AbstractTest {
         Long mindisk = 0L;
         Long minram = 0L;
         Image.ImageVisibility vis = Image.ImageVisibility.PUBLIC;
+        String key1 = "test-key1";
+        String key2 = "test-key2";
+        String key3 = "id";
+        String value1 = "test-value1";
+        String value2 = "test-value2";
+        String value3 = "test-value3";
         Image im = Builders.imageV2()
                 .id(id)
                 .name(name)
@@ -88,6 +95,9 @@ public class ImageV2Tests extends AbstractTest {
                 .minDisk(mindisk)
                 .minRam(minram)
                 .visibility(vis)
+                .additionalProperty(key1, value1)
+                .additionalProperty(key2, value2)
+                .additionalProperty(key3, value3)
                 .build();
         Image image = osv3().imagesV2().create(im);
         assertNotNull(image);
@@ -98,6 +108,9 @@ public class ImageV2Tests extends AbstractTest {
         assertEquals(image.getVisibility(), vis);
         assertEquals(image.getMinDisk(), mindisk);
         assertEquals(image.getMinRam(), minram);
+        assertEquals(image.getAdditionalPropertyValue(key1), value1);
+        assertEquals(image.getAdditionalPropertyValue(key2), value2);
+        assertNull(image.getAdditionalPropertyValue(key3));
     }
 
     public void testDeleteImage() throws IOException {

--- a/core-test/src/main/resources/image/v2/image.json
+++ b/core-test/src/main/resources/image/v2/image.json
@@ -17,5 +17,7 @@
   "owner": "48e3c436235547a68324c2891bea41ac",
   "virtual_size": null,
   "min_ram": 0,
-  "schema": "/v2/schemas/image"
+  "schema": "/v2/schemas/image",
+  "test-key1": "test-value1",
+  "test-key2": "test-value2"
 }

--- a/core/src/main/java/org/openstack4j/model/image/v2/Image.java
+++ b/core/src/main/java/org/openstack4j/model/image/v2/Image.java
@@ -250,4 +250,10 @@ public interface Image extends BasicResource, Buildable<ImageBuilder> {
      * @return Virtual size of image in bytes (READ-ONLY)
      */
     Long getVirtualSize();
+
+    /**
+     * @return Additional property's value from key
+     * https://developer.openstack.org/api-ref/image/v2/index.html#create-an-image
+     */
+    String getAdditionalPropertyValue(String key);
 }

--- a/core/src/main/java/org/openstack4j/model/image/v2/builder/ImageBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/image/v2/builder/ImageBuilder.java
@@ -87,4 +87,9 @@ public interface ImageBuilder extends Buildable.Builder<ImageBuilder, Image> {
      * @see Image#getRamdiskId()
      */
     ImageBuilder ramdiskId(String ramdiskId);
+
+    /**
+     * @see Image#getAdditionalPropertyValue()
+     */
+    ImageBuilder additionalProperty(String key, String value);
 }

--- a/core/src/main/java/org/openstack4j/openstack/image/v2/domain/GlanceImage.java
+++ b/core/src/main/java/org/openstack4j/openstack/image/v2/domain/GlanceImage.java
@@ -1,7 +1,10 @@
 package org.openstack4j.openstack.image.v2.domain;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.openstack4j.model.common.builder.BasicResourceBuilder;
 import org.openstack4j.model.image.v2.ContainerFormat;
@@ -10,9 +13,13 @@ import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.image.v2.builder.ImageBuilder;
 import org.openstack4j.openstack.common.ListResult;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 /**
  * A glance v2.0-2.3 image model implementation
@@ -21,6 +28,35 @@ import com.google.common.base.Objects;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GlanceImage implements Image {
+
+    private static final Set<String> RESERVED_KEYS = Sets.newHashSet(Arrays.asList(new String[] { 
+            "id",
+            "name",
+            "tags",
+            "status",
+            "container_format",
+            "disk_format",
+            "created_at",
+            "updated_at",
+            "min_disk",
+            "min_ram",
+            "protected",
+            "checksum",
+            "owner",
+            "visibility",
+            "size",
+            "locations",
+            "direct_url",
+            "self",
+            "file",
+            "schema",
+            "architecture",
+            "instance_uuid",
+            "kernel_id",
+            "os_version",
+            "os_distro",
+            "ramdisk_id",
+            "virtual_size" }));
 
     private static final long serialVersionUID = 1L;
 
@@ -92,6 +128,7 @@ public class GlanceImage implements Image {
     @JsonProperty("virtual_size")
     private Long virtualSize;
 
+    private Map<String, String> additionalProperties = Maps.newHashMap();
 
     /**
      * {@inheritDoc}
@@ -326,6 +363,26 @@ public class GlanceImage implements Image {
      * {@inheritDoc}
      */
     @Override
+    public String getAdditionalPropertyValue(String key) {
+        return additionalProperties.get(key);
+    }
+
+    @JsonAnyGetter
+    public Map<String, String> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String key, String value) {
+        if (key != null && !RESERVED_KEYS.contains(key)) {
+            additionalProperties.put(key, value);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public ImageBuilder toBuilder() {
         return new ImageConcreteBuilder(this);
     }
@@ -508,6 +565,17 @@ public class GlanceImage implements Image {
         @Override
         public ImageBuilder ramdiskId(String ramdiskId) {
             m.ramdiskId = ramdiskId;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ImageBuilder additionalProperty(String key, String value) {
+            if (key != null && !RESERVED_KEYS.contains(key)) {
+                m.additionalProperties.put(key, value);
+            }
             return this;
         }
 


### PR DESCRIPTION
Currently, there is no way to passing additional properties (e.g. hw_vif_model, hw_disk_bus) when creating image through Glance V2
https://developer.openstack.org/api-ref/image/v2/index.html?expanded=create-an-image-detail#create-an-image