### PR TITLE
Add client certificate for keystone tokenless

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneAuthenticationTests.java
@@ -4,15 +4,21 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import okhttp3.mockwebserver.RecordedRequest;
 import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.OSClient;
 import org.openstack4j.api.OSClient.OSClientV3;
 import org.openstack4j.api.exceptions.RegionEndpointNotFoundException;
+import org.openstack4j.core.transport.Config;
 import org.openstack4j.model.common.Identifier;
 import org.openstack4j.model.identity.AuthVersion;
 import org.openstack4j.model.identity.v3.User;
 import org.openstack4j.openstack.OSFactory;
+import org.openstack4j.openstack.identity.v3.domain.KeystoneToken;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -349,6 +355,26 @@ public class KeystoneAuthenticationTests extends AbstractTest {
 
     }
 
+    /**
+     * check headers whether right from request
+     *
+     * @throws Exception
+     */
+    public void pass_headers_Test() throws Exception {
 
+        respondWith(JSON_USERS);
+
+        Map header = new HashMap();
+        String key = "X-Domain-Id";
+        String value = "default";
+        header.put(key, value);
+        KeystoneToken token = new KeystoneToken();
+        token.setEndpoint(authURL("/v3"));
+        OSClient.OSClientV3 osClient = OSFactory.clientFromToken(token).headers(header);
+        osClient.identity().users().list();
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals(request.getHeader(key), value);
+    }
 
 }

--- a/core/src/main/java/org/openstack4j/api/OSClient.java
+++ b/core/src/main/java/org/openstack4j/api/OSClient.java
@@ -23,6 +23,7 @@ import org.openstack4j.model.identity.v2.Access;
 import org.openstack4j.model.identity.v3.Token;
 import org.openstack4j.api.magnum.MagnumService;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -60,6 +61,14 @@ public interface OSClient< T extends OSClient<T>> {
      * @return OSClient for method chaining
      */
     T perspective(Facing perspective);
+
+    /**
+     * Passes the Headers for the current Session(Client)
+     *
+     * @param headers the headers to use for keystone tokenless
+     * @return OSClient for method chaining
+     */
+    T headers(Map<String, ? extends Object> headers);
 
     /**
      * Gets the supported services. A set of ServiceTypes will be returned

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -112,7 +112,12 @@ public class BaseOpenStackService {
         }
         RequestBuilder<R> req = HttpRequest.builder(returnType).endpointTokenProvider(ses).config(ses.getConfig())
                 .method(method).path(path);
-        return new Invocation<R>(req, serviceType, endpointFunc);
+        Map headers = ses.getHeaders();
+        if (headers != null && headers.size() > 0){
+            return new Invocation<R>(req, serviceType, endpointFunc).headers(headers);
+        }else{
+            return new Invocation<R>(req, serviceType, endpointFunc);
+        }
     }
 
     protected static class Invocation<R> {

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -61,6 +62,7 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
     String region;
     Set<ServiceType> supports;
     CloudProvider provider;
+    Map<String, ? extends Object> headers;
     EndpointURLResolver fallbackEndpointUrlResolver = new DefaultEndpointURLResolver();
 
     @SuppressWarnings("rawtypes")
@@ -225,6 +227,18 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
 
     public CloudProvider getProvider() {
         return (provider == null) ? CloudProvider.UNKNOWN : provider;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public T headers(Map<String, ? extends Object> headers) {
+        this.headers = headers;
+        return (T) this;
+    }
+
+    public Map<String, ? extends Object> getHeaders(){
+        return this.headers;
     }
 
     /**


### PR DESCRIPTION
Currently, keystone supports client certificate without having to issue a
token, so it is necessary to add client certificate to support keystone
tokenless feature.