### PR TITLE
SenlinNodeService: details about physical object that backs the node

### DIFF
--- a/core/src/main/java/org/openstack4j/api/senlin/SenlinNodeService.java
+++ b/core/src/main/java/org/openstack4j/api/senlin/SenlinNodeService.java
@@ -44,6 +44,14 @@ public interface SenlinNodeService {
 	Node get(String nodeID);
 
 	/**
+	 * returns details of a {@link Node}
+	 * @param nodeID Id of {@link Node}
+	 * @param showDetails {@literal true} to retrieve the properties about the physical object that backs the node
+	 * @return Node
+	 */
+	Node get(String nodeID, boolean showDetails);
+
+	/**
 	 * Deletes the specified {@link Node} from the server.
 	 *
 	 * @param nodeID

--- a/core/src/main/java/org/openstack4j/openstack/senlin/internal/SenlinNodeServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/senlin/internal/SenlinNodeServiceImpl.java
@@ -33,8 +33,14 @@ public class SenlinNodeServiceImpl extends BaseSenlinServices implements SenlinN
 
 	@Override
 	public Node get(String nodeID) {
+		return get(nodeID, false);	//false for backward compatibility
+	}
+
+	@Override
+	public Node get(final String nodeID, final boolean showDetails) {
 		checkNotNull(nodeID);
-		return get(SenlinNode.class, uri("/nodes/%s", nodeID)).execute();
+		//see at https://developer.openstack.org/api-ref/clustering/?expanded=show-node-details-detail
+		return get(SenlinNode.class, uri("/nodes/%s", nodeID)).param("show_details", showDetails).execute();
 	}
 
 	@Override


### PR DESCRIPTION
A new method in `SenlinNodeService` allows to obtain details (via `Node.getDetails()`) about physical object that backs the cluster node correctly. This can be done using `show_details` query parameter. See details about this parameter [here](https://developer.openstack.org/api-ref/clustering/?expanded=show-node-details-detail)