### PR TITLE
Add http headers for supporting keystone tokenless

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,35 @@ OSClientV3 os = OSFactory.builderV3()
                 .scopeToProject(Identifier.byId("project id"))
                 .authenticate());
 ```
+(5) authenticate using client certificate
+```bash
+openssl pkcs12 -export -out client-certificate-keystore.p12  -inkey key.pem -in cert.pem -certfile ca.pem
+Enter Export Password:encrypt
+Verifying - Enter Export Password:encrypt
+```
+```java
+String encrypt =  "encrypt";
+KeyStore keyStore = KeyStore.getInstance("PKCS12");
+keyStore.load(new FileInputStream(new File("client-certificate-keystore.p12")), encrypt.toCharArray());
+SSLContext sslContext = SSLContexts.custom()
+        //ignore server verify
+        .loadTrustMaterial(new TrustStrategy() {
+            @Override
+            public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                return true;
+            }
+        })
+        .loadKeyMaterial(keyStore,encrypt.toCharArray())
+        .build();
+Config config = Config.newConfig();
+config.withSSLContext(sslContext);
+OSClient.OSClientV3 osClient = OSFactory.builderV3()
+        .endpoint("https://<fqdn>:5000/v3")
+        .withConfig(config)
+        .scopeToProject(Identifier.byId("project id"))
+        //.scopeToDomain(Identifier.byId("domain id"))
+        .authenticate();
+```
 
 #### Identity Operations (Keystone) V3
 

--- a/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneTokenlessTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/v3/KeystoneTokenlessTest.java
@@ -1,0 +1,45 @@
+package org.openstack4j.api.identity.v3;
+
+import okhttp3.mockwebserver.RecordedRequest;
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.OSClient;
+import org.openstack4j.core.transport.ClientConstants;
+import org.openstack4j.model.common.Identifier;
+import org.openstack4j.openstack.OSFactory;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests the Identity/Keystone API version 3 Keystone tokenless
+ */
+@Test(groups = "idV3", suiteName = "Identity/V3/Keystone")
+public class KeystoneTokenlessTest extends AbstractTest {
+
+    private static final String JSON_USERS = "/identity/v3/users.json";
+    private static final String DOMAIN_ID = "default";
+
+    /**
+     * check headers whether right from request
+     *
+     * @throws Exception
+     */
+    public void pass_headers_Test() throws Exception {
+
+        respondWith(JSON_USERS);
+
+        OSClient.OSClientV3 osClient = OSFactory.builderV3()
+                .endpoint(authURL("/v3"))
+                .scopeToDomain(Identifier.byId(DOMAIN_ID))
+                .authenticate();
+        osClient.identity().users().list();
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals(request.getHeader(ClientConstants.HEADER_X_DOMAIN_ID), DOMAIN_ID);
+    }
+
+    @Override
+    protected Service service() {
+        return Service.IDENTITY;
+    }
+}

--- a/core/src/main/java/org/openstack4j/api/OSClient.java
+++ b/core/src/main/java/org/openstack4j/api/OSClient.java
@@ -23,6 +23,7 @@ import org.openstack4j.model.identity.v2.Access;
 import org.openstack4j.model.identity.v3.Token;
 import org.openstack4j.api.magnum.MagnumService;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -60,6 +61,14 @@ public interface OSClient< T extends OSClient<T>> {
      * @return OSClient for method chaining
      */
     T perspective(Facing perspective);
+
+    /**
+     * Passes the Headers for the current Session(Client)
+     *
+     * @param headers the headers to use for keystone tokenless
+     * @return OSClient for method chaining
+     */
+    T headers(Map<String, ? extends Object> headers);
 
     /**
      * Gets the supported services. A set of ServiceTypes will be returned

--- a/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
+++ b/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
@@ -9,6 +9,12 @@ public final class ClientConstants {
 
     public static final String HEADER_X_AUTH_TOKEN = "X-Auth-Token";
     public static final String HEADER_X_SUBJECT_TOKEN = "X-Subject-Token";
+    public static final String HEADER_X_PROJECT_ID = "X-Project-Id";
+    public static final String HEADER_X_PROJECT_NAME = "X-Project-Name";
+    public static final String HEADER_X_PROJECT_DOMAIN_ID = "X-Project-Domain-Id";
+    public static final String HEADER_X_PROJECT_DOMAIN_NAME = "X-Project-Domain-Name";
+    public static final String HEADER_X_DOMAIN_ID = "X-Domain-Id";
+    public static final String HEADER_X_DOMAIN_NAME = "X-Domain-Name";
     public static final String HEADER_CONTENT_LANGUAGE = "Content-Language";
     public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
     public static final String HEADER_CONTENT_TYPE = "Content-Type";

--- a/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
@@ -10,6 +10,7 @@ import org.openstack4j.api.exceptions.AuthenticationException;
 import org.openstack4j.api.types.Facing;
 import org.openstack4j.core.transport.Config;
 import org.openstack4j.model.common.Identifier;
+import org.openstack4j.openstack.common.Auth;
 import org.openstack4j.openstack.identity.v2.domain.Credentials;
 import org.openstack4j.openstack.identity.v2.domain.RaxApiKeyCredentials;
 import org.openstack4j.openstack.identity.v2.domain.TokenAuth;
@@ -162,7 +163,11 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
             if (tokenId != null && tokenId.length() > 0)
                 return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(tokenId, scope), endpoint, perspective, config,
                         provider);
-            return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope), endpoint, perspective,
+            if (user != null && user.length() > 0)
+                return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(user, password, domain, scope), endpoint, perspective,
+                        config, provider);
+            // Use tokenless auth finally
+            return (OSClientV3) OSAuthenticator.invoke(new KeystoneAuth(scope, Auth.Type.TOKENLESS), endpoint, perspective,
                     config, provider);
         }
 

--- a/core/src/main/java/org/openstack4j/openstack/common/Auth.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/Auth.java
@@ -4,6 +4,6 @@ import org.openstack4j.model.ModelEntity;
 
 public interface Auth extends ModelEntity {
 
-	public enum Type { CREDENTIALS, TOKEN, RAX_APIKEY }
+	public enum Type { CREDENTIALS, TOKEN, RAX_APIKEY, TOKENLESS }
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
@@ -54,6 +54,11 @@ public class KeystoneAuth implements Authentication, AuthStore {
         this.type = Type.CREDENTIALS;
     }
 
+    public KeystoneAuth(AuthScope scope, Type type){
+        this.scope = scope;
+        this.type = type;
+    }
+
     protected KeystoneAuth(Type type) {
         this.type = type;
     }

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -112,7 +112,12 @@ public class BaseOpenStackService {
         }
         RequestBuilder<R> req = HttpRequest.builder(returnType).endpointTokenProvider(ses).config(ses.getConfig())
                 .method(method).path(path);
-        return new Invocation<R>(req, serviceType, endpointFunc);
+        Map headers = ses.getHeaders();
+        if (headers != null && headers.size() > 0){
+            return new Invocation<R>(req, serviceType, endpointFunc).headers(headers);
+        }else{
+            return new Invocation<R>(req, serviceType, endpointFunc);
+        }
     }
 
     protected static class Invocation<R> {

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
@@ -11,6 +11,7 @@ import org.openstack4j.core.transport.*;
 import org.openstack4j.core.transport.internal.HttpExecutor;
 import org.openstack4j.model.identity.AuthStore;
 import org.openstack4j.model.identity.AuthVersion;
+import org.openstack4j.model.identity.v3.Authentication;
 import org.openstack4j.model.identity.v3.Token;
 import org.openstack4j.openstack.common.Auth;
 import org.openstack4j.openstack.common.Auth.Type;
@@ -24,6 +25,9 @@ import org.openstack4j.openstack.internal.OSClientSession.OSClientSessionV2;
 import org.openstack4j.openstack.internal.OSClientSession.OSClientSessionV3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Responsible for authenticating and re-authenticating sessions for V2 and V3
@@ -147,6 +151,35 @@ public class OSAuthenticator {
     }
 
     private static OSClientV3 authenticateV3(KeystoneAuth auth, SessionInfo info, Config config) {
+        if (auth.getType().equals(Type.TOKENLESS)){
+            Map headers = new HashMap();
+            Authentication.Scope.Project project = auth.getScope().getProject();
+            if (project != null){
+                if (!isEmpty(project.getId()))
+                    headers.put(ClientConstants.HEADER_X_PROJECT_ID, project.getId());
+                if (!isEmpty(project.getName()))
+                    headers.put(ClientConstants.HEADER_X_PROJECT_NAME, project.getName());
+                Authentication.Scope.Domain domain = project.getDomain();
+                if (domain != null){
+                    if (!isEmpty(domain.getId()))
+                        headers.put(ClientConstants.HEADER_X_PROJECT_DOMAIN_ID, domain.getId());
+                    if (!isEmpty(domain.getName()))
+                        headers.put(ClientConstants.HEADER_X_PROJECT_DOMAIN_NAME, domain.getName());
+                }
+            }else{
+                Authentication.Scope.Domain domain = auth.getScope().getDomain();
+                if (domain != null){
+                    if (!isEmpty(domain.getId()))
+                        headers.put(ClientConstants.HEADER_X_DOMAIN_ID, domain.getId());
+                    if (!isEmpty(domain.getName()))
+                        headers.put(ClientConstants.HEADER_X_DOMAIN_NAME, domain.getName());
+                }
+            }
+            KeystoneToken keystoneToken = new KeystoneToken();
+            keystoneToken.setEndpoint(info.endpoint);
+            return OSClientSessionV3.createSession(keystoneToken, null, null, config).headers(headers);
+        }
+
         HttpRequest<KeystoneToken> request = HttpRequest.builder(KeystoneToken.class)
                 .header(ClientConstants.HEADER_OS4J_AUTH, TOKEN_INDICATOR).endpoint(info.endpoint)
                 .method(HttpMethod.POST).path("/auth/tokens").config(config).entity(auth).build();
@@ -202,5 +235,11 @@ public class OSAuthenticator {
             this.reLinkToExistingSession = reLinkToExistingSession;
             this.provider = provider;
         }
+    }
+
+    private static boolean isEmpty(String str){
+        if (str != null && str.length() > 0)
+            return false;
+        return true;
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -61,6 +62,7 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
     String region;
     Set<ServiceType> supports;
     CloudProvider provider;
+    Map<String, ? extends Object> headers;
     EndpointURLResolver fallbackEndpointUrlResolver = new DefaultEndpointURLResolver();
 
     @SuppressWarnings("rawtypes")
@@ -225,6 +227,18 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
 
     public CloudProvider getProvider() {
         return (provider == null) ? CloudProvider.UNKNOWN : provider;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public T headers(Map<String, ? extends Object> headers) {
+        this.headers = headers;
+        return (T) this;
+    }
+
+    public Map<String, ? extends Object> getHeaders(){
+        return this.headers;
     }
 
     /**


### PR DESCRIPTION
Currently, keystone supports client certificate without having to issue a
token, so it is necessary to add http headers to support this feature.