### PR TITLE
designate v2 service

### DIFF
--- a/core-integration-test/src/test/groovy/org/openstack4j/api/dns/v2/DesignateRecordsetServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/dns/v2/DesignateRecordsetServiceSpec.groovy
@@ -1,0 +1,161 @@
+/*
+package org.openstack4j.api.dns.v2
+
+import co.freeside.betamax.TapeMode
+import groovy.util.logging.Slf4j
+import org.junit.Rule
+import org.junit.rules.TestName
+import org.openstack4j.api.AbstractSpec
+import org.openstack4j.api.Builders
+import org.openstack4j.api.OSClient.OSClientV3
+import org.openstack4j.model.common.ActionResponse
+import org.openstack4j.model.common.Identifier
+import org.openstack4j.model.dns.v2.Recordset
+import org.openstack4j.openstack.OSFactory
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.TapeMode
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
+import spock.lang.IgnoreIf
+
+@Slf4j
+class DesignateRecordsetServiceSpec extends AbstractSpec {
+
+    @Rule TestName DesignateRecordsetServiceTest
+    @Rule public RecorderRule recorderRule = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "identity.v3"))
+                    //.defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .defaultMode(TapeMode.WRITE_SEQUENTIAL)
+                    .build());
+
+    // used for domain crud tests
+    def static final String RECORDSET_NAME = "Atest."
+    def static final String RECORDSET_TYPE = "A"
+    def static final List<String> RECORDSET_RECORDS= ["10.1.0.2"]
+    def static final String RECORDSET_DESCRIPTION = "This is my recordset."
+    def String ZONE_ID, ZONE_NAME, RECORDSET_ID
+
+    static final boolean skipTest
+
+    static {
+        if(
+        USER_ID == null ||
+                AUTH_URL == null ||
+                PASSWORD == null ||
+                DOMAIN_ID == null ) {
+
+            skipTest = true
+        }
+        else{
+            skipTest = false
+        }
+    }
+
+
+    // run before the first feature method; similar to JUnit's @BeforeClass
+    def setupSpec() {
+
+        if( skipTest != true ) {
+            log.info("USER_NAME: " + USER_NAME)
+            log.info("USER_DOMAIN_ID: " + USER_DOMAIN_ID)
+            log.info("AUTH_URL: " + AUTH_URL)
+            log.info("PROJECT_ID: " + PROJECT_ID)
+        }
+        else {
+            log.warn("Skipping integration-test cases because not all mandatory attributes are set.");
+        }
+    }
+
+    def setup() {
+        log.info("-> Test: '$DesignateRecordsetServiceTest.methodName'")
+    }
+
+
+    // ------------ DomainService Tests ------------
+
+    @IgnoreIf({ skipTest })
+    @Betamax(tape="recordsetService_crud")
+    def "dns/v2/recordset test cases"() {
+
+        given: "an authenticated OSClient"
+        OSClientV3 os = OSFactory.builderV3()
+                .endpoint(AUTH_URL)
+                .credentials(USER_NAME, PASSWORD, Identifier.byId(USER_DOMAIN_ID))
+                .scopeToProject(Identifier.byId(PROJECT_ID))
+                .withConfig(CONFIG_PROXY_BETAMAX)
+                .authenticate()
+
+        and: "get the id of a dns zone"
+        ZONE_ID = os.dns().zones().list().first().getId()
+
+        and: "the id of the zone shouldn't be null"
+        ZONE_ID != null
+
+        and: "get name of the zone"
+        ZONE_NAME = os.dns().zones().list().first().getName()
+
+        and: "the name of the zone shouldn't be null"
+        ZONE_NAME != null
+
+        when: "we try to create a recordset with argument 'null' "
+        os.dns().recordsets().create(null, null)
+
+        then: "a NPE is thrown"
+        thrown NullPointerException
+
+        when: "creating a recordset"
+        Recordset recordset = os.dns().recordsets().create(ZONE_ID, RECORDSET_NAME+ZONE_NAME, RECORDSET_TYPE, RECORDSET_RECORDS)
+
+        then: "the attributes of the recordset should be equal"
+        recordset.getName() == RECORDSET_NAME+ZONE_NAME
+        recordset.getZoneId() == ZONE_ID
+        recordset.getType() == RECORDSET_TYPE
+        recordset.getRecords() == RECORDSET_RECORDS
+
+        when: "getting the id of the recordset"
+        RECORDSET_ID = recordset.getId()
+
+        then: "this shouldn't be null"
+        RECORDSET_ID != null
+
+        when: "list recordsets owned by project"
+        List<? extends Recordset> recordsetList = os.dns().recordsets().list()
+
+        then: "the list shouldn't be empty and the recordset belongs to the project"
+        recordsetList.isEmpty() == false
+        recordsetList.first().getProjectId() == PROJECT_ID
+
+        when: "list recordsets in a zone"
+        List<? extends Recordset> recordsetListZone = os.dns().recordsets().list(ZONE_ID)
+
+        then: "the list shouldn't be empty and the recordset is within the zone"
+        recordsetListZone.isEmpty() == false
+        recordsetListZone.first().getZoneId() == ZONE_ID
+
+        when: "get a recordset by id"
+        Recordset recordsetById = os.dns().recordsets().get(ZONE_ID,RECORDSET_ID)
+
+        then: "the attributes of the recordset should be equal"
+        recordsetById.getZoneId() == ZONE_ID
+        recordsetById.getId() == RECORDSET_ID
+
+        when: "updating a recordset"
+        Recordset recordsetUpdated = os.dns().recordsets().update(ZONE_ID, Builders.recordset().id(RECORDSET_ID).description(RECORDSET_DESCRIPTION).build())
+
+        then: "the attribute of the recordset should be updated"
+        recordsetUpdated.getDescription() == RECORDSET_DESCRIPTION
+
+        when: "deleting a recordset"
+        ActionResponse deleteRecordset = os.dns().recordsets().delete(ZONE_ID,RECORDSET_ID)
+
+        then: "this should be successful"
+        deleteRecordset.isSuccess() == true
+
+        cleanup: "delete created recordset in case of errors"
+        os.dns().recordsets().delete(ZONE_ID,RECORDSET_ID)
+
+    }
+}
+*/

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/dns/v2/DesignateZoneServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/dns/v2/DesignateZoneServiceSpec.groovy
@@ -1,0 +1,169 @@
+/*
+package org.openstack4j.api.dns.v2
+
+import co.freeside.betamax.TapeMode
+import groovy.util.logging.Slf4j
+import org.junit.Rule
+import org.junit.rules.TestName
+import org.openstack4j.api.AbstractSpec
+import org.openstack4j.api.Builders
+import org.openstack4j.api.OSClient.OSClientV3
+import org.openstack4j.model.common.ActionResponse
+import org.openstack4j.model.common.Identifier
+import org.openstack4j.model.dns.v2.Nameserver
+import org.openstack4j.model.dns.v2.Zone
+import org.openstack4j.model.dns.v2.ZoneType
+import org.openstack4j.openstack.OSFactory
+import software.betamax.Configuration
+import software.betamax.MatchRules
+import software.betamax.TapeMode
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
+import spock.lang.IgnoreIf
+
+@Slf4j
+class DesignateZoneServiceSpec extends AbstractSpec {
+
+    @Rule TestName DesignateZoneServiceTest
+    @Rule public RecorderRule recorderRule = new RecorderRule(
+            Configuration.builder()
+                    .tapeRoot(new File(TAPEROOT + "dns.v2"))
+                    //.defaultMatchRules(MatchRules.method, MatchRules.path, MatchRules.queryParams)
+                    .defaultMode(TapeMode.WRITE_ONLY)
+                    .build());
+
+    // used for domain crud tests
+    def static final String ZONE_NAME = "b.org."
+    def static final String ZONE_EMAIL = "a@b.org"
+    def static final Integer ZONE_TTL = 3602
+    def static final ZoneType ZONE_TYPE = ZoneType.PRIMARY
+    def static final String ZONE_DESCRIPTION = "This is my zone."
+    def static final String NAMESERVER_HOSTNAME = "hostname"
+    def String ZONE_ID
+
+    static final boolean skipTest
+
+    static {
+        if(
+        USER_ID == null ||
+        AUTH_URL == null ||
+        PASSWORD == null ||
+        DOMAIN_ID == null ) {
+
+            skipTest = true
+        }
+        else{
+            skipTest = false
+        }
+    }
+
+
+    // run before the first feature method; similar to JUnit's @BeforeClass
+    def setupSpec() {
+
+        if( skipTest != true ) {
+            log.info("USER_NAME: " + USER_NAME)
+            log.info("USER_DOMAIN_ID: " + USER_DOMAIN_ID)
+            log.info("AUTH_URL: " + AUTH_URL)
+            log.info("PROJECT_ID: " + PROJECT_ID)
+        }
+        else {
+            log.warn("Skipping integration-test cases because not all mandatory attributes are set.");
+        }
+    }
+
+    def setup() {
+        log.info("-> Test: '$DesignateZoneServiceTest.methodName'")
+    }
+
+
+    // ------------ DomainService Tests ------------
+
+    @IgnoreIf({ skipTest })
+    @Betamax(tape="zoneService_crud")
+    def "dns/v2/zone service test cases"() {
+
+        given: "an authenticated OSClient"
+        OSClientV3 os = OSFactory.builderV3()
+                .endpoint(AUTH_URL)
+                .credentials(USER_NAME, PASSWORD, Identifier.byId(USER_DOMAIN_ID))
+                .scopeToProject(Identifier.byId(PROJECT_ID))
+                .withConfig(CONFIG_PROXY_BETAMAX)
+                .authenticate()
+
+        when: "we try to create a zone with argument 'null' "
+        os.dns().zones().create(null)
+
+        then: "a NPE is thrown"
+        thrown NullPointerException
+
+        // commented out due to permission foo
+//        when: "a new domain is created using DomainBuilder with valid arguments"
+//        Zone zone = Builders.zone()
+//                .name(ZONE_NAME)
+//                .email(ZONE_EMAIL)
+//                .ttl(ZONE_TTL)
+//                .description(ZONE_DESCRIPTION)
+//                .type(ZONE_TYPE)
+//                .build()
+//
+//        and:
+//        Zone newZone = os.dns().zones().create(zone)
+//
+//        then: "verify that the new domain is correct"
+//        newZone.getId != null
+//        newZone.getName() == ZONE_NAME
+//        newZone.getEmail() == ZONE_EMAIL
+//        newZone.getTTL() == ZONE_TTL
+//        newZone.getDescription() == ZONE_DESCRIPTION
+//        newZone.getType() == ZONE_TYPE
+
+        when: "listing all zones"
+        List<? extends Zone> zoneList = os.dns().zones().list()
+
+        then: "the list shouldn't be empty"
+        zoneList.isEmpty() == false
+
+        when: "get the id of the first zone"
+        ZONE_ID = zoneList.first().getId()
+
+        then: "the id of the first item shouldn't be null"
+        ZONE_ID != null
+
+        and: "the attributes of the zone should be equal"
+        zoneList.first().getProjectId() == PROJECT_ID
+        zoneList.first().getType() == ZONE_TYPE
+        zoneList.first().getTTL() == ZONE_TTL
+
+        when: "get a zone by id"
+        Zone zoneById = os.dns().zones().get(ZONE_ID)
+
+        then: "the attributes of the zone should be as expected "
+        zoneById.getId() == ZONE_ID
+        zoneById.getProjectId() == PROJECT_ID
+
+        when: "get nameserver for a zone specified by id"
+        List<? extends Nameserver> nameserverList = os.dns().zones().listNameservers(ZONE_ID)
+
+        then: "this list shouldn't be empty"
+        nameserverList.isEmpty() == false
+        nameserverList.first().getHostname() == NAMESERVER_HOSTNAME
+        nameserverList.first().getPriority() == 1
+
+        // commented out due to permission foo
+//        when: "updating a zone description"
+//        Zone zoneUpdated = os.dns().zones().update(Builders.zone().id(ZONE_ID).description(ZONE_DESCRIPTION).build())
+//
+//        then: "the description should be updated"
+//        zoneUpdated.getDescription() == ZONE_DESCRIPTION
+
+        // commented out due to permission foo
+//        when: "deleting a zone"
+//        ActionResponse deleteZoneResponse = os.dns().zones().delete(ZONE_ID)
+//
+//        then: "this should be successfull"
+//        deleteZoneResponse.isSuccess() == true
+
+    }
+}
+*/

--- a/core-test/src/main/java/org/openstack4j/api/AbstractTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/AbstractTest.java
@@ -42,7 +42,8 @@ public abstract class AbstractTest {
         IMAGE(9292),
         ARTIFACT(9494),
         CLUSTERING(8778),
-        APP_CATALOG(8082);
+        APP_CATALOG(8082),
+        DNS(9001);
 
         private final int port;
 
@@ -120,7 +121,7 @@ public abstract class AbstractTest {
      * Responds with specified status code and json body
      * 
      * @param statusCode the status code to respond with
-     * @param body the json body
+     * @param jsonBody the json body
      */
     protected void respondWith(int statusCode, String jsonBody) {
         Map<String, String> headers = new HashMap<String, String>();

--- a/core-test/src/main/java/org/openstack4j/api/AbstractTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/AbstractTest.java
@@ -1,21 +1,31 @@
 package org.openstack4j.api;
 
-import com.fasterxml.jackson.annotation.JsonInclude.*;
-import com.fasterxml.jackson.databind.*;
-import com.google.common.io.*;
-import okhttp3.mockwebserver.*;
-import org.bouncycastle.util.io.*;
-import org.openstack4j.api.OSClient.*;
-import org.openstack4j.core.transport.internal.*;
-import org.openstack4j.openstack.*;
-import org.openstack4j.openstack.identity.v2.domain.*;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.io.ByteStreams;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.bouncycastle.util.io.Streams;
+import org.openstack4j.api.OSClient.OSClientV2;
+import org.openstack4j.api.OSClient.OSClientV3;
+import org.openstack4j.core.transport.internal.HttpExecutor;
+import org.openstack4j.openstack.OSFactory;
+import org.openstack4j.openstack.identity.v2.domain.KeystoneAccess;
 import org.openstack4j.openstack.identity.v3.domain.KeystoneToken;
-import org.slf4j.*;
-import org.testng.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Base Test class which handles Mocking a Webserver to fullfill and test
@@ -26,19 +36,19 @@ import java.util.*;
 public abstract class AbstractTest {
 
     protected enum Service {
-        IDENTITY(5000), 
+        IDENTITY(5000),
         NETWORK(9696),
-        COMPUTE(8774), 
-        BLOCK_STORAGE(8776), 
-        METERING(8087), 
-        TELEMETRY(8087), 
-        SHARE(8786), 
+        COMPUTE(8774),
+        BLOCK_STORAGE(8776),
+        METERING(8087),
+        TELEMETRY(8087),
+        SHARE(8786),
         OBJECT_STORAGE(8800),
         BARBICAN(9311),
         MAGNUM(9511),
         ORCHESTRATION(8004),
         DATABASE(8779),
-    	TACKER(9890),
+        TACKER(9890),
         IMAGE(9292),
         ARTIFACT(9494),
         CLUSTERING(8778),
@@ -52,7 +62,7 @@ public abstract class AbstractTest {
         }
 
     }
-    
+
     private final Logger LOG = LoggerFactory.getLogger(getClass().getName());
 
     protected static final String JSON_ACCESS = "/identity/v2/access.json";
@@ -100,7 +110,7 @@ public abstract class AbstractTest {
 
     /**
      * Responds with specified status code and no body
-     * 
+     *
      * @param statusCode the status code to respond with
      */
     protected void respondWith(int statusCode) {
@@ -109,8 +119,8 @@ public abstract class AbstractTest {
 
     /**
      * Responds with specified status code, no body and optional headers
-     * 
-     * @param headers optional headers
+     *
+     * @param headers    optional headers
      * @param statusCode the status code to respond with
      */
     protected void respondWith(Map<String, String> headers, int statusCode) {
@@ -119,9 +129,9 @@ public abstract class AbstractTest {
 
     /**
      * Responds with specified status code and json body
-     * 
+     *
      * @param statusCode the status code to respond with
-     * @param jsonBody the json body
+     * @param jsonBody   the json body
      */
     protected void respondWith(int statusCode, String jsonBody) {
         Map<String, String> headers = new HashMap<String, String>();
@@ -131,10 +141,10 @@ public abstract class AbstractTest {
 
     /**
      * Responds with specified status code, body and optional headers
-     * 
-     * @param headers optional headers
+     *
+     * @param headers    optional headers
      * @param statusCode the status code to respond with
-     * @param body the response body
+     * @param body       the response body
      */
     protected void respondWith(Map<String, String> headers, int statusCode, String body) {
         MockResponse r = new MockResponse();
@@ -151,9 +161,9 @@ public abstract class AbstractTest {
     /**
      * Responds with given header, status code, body from json resource file.
      *
-     * @param headers the specified header
+     * @param headers    the specified header
      * @param statusCode the status code to respond with
-     * @param resource the json resource file
+     * @param resource   the json resource file
      * @throws IOException Signals that an I/O exception has occurred
      */
     protected void respondWithHeaderAndResource(Map<String, String> headers, int statusCode, String resource)
@@ -174,16 +184,16 @@ public abstract class AbstractTest {
      * Callers should use this to verify the request was sent as intended.
      * This method will block until the request is available, possibly forever.
      * <br/>
-     * <b>Be aware that this method will catch all the previous requests made 
+     * <b>Be aware that this method will catch all the previous requests made
      * to the mock server, also from other previous tests!
      * Make sure to take all the requests made by methods in the same test class.</b>
-     * 
+     *
      * @return the head of the request queue
      */
     protected RecordedRequest takeRequest() throws InterruptedException {
         return server.takeRequest();
     }
-    
+
     protected String authURL(String path) {
         return String.format("http://%s:5000%s", getHost(), path);
     }
@@ -201,7 +211,7 @@ public abstract class AbstractTest {
     protected void associateClientV2(OSClientV2 osv2) {
         this.osv2 = osv2;
     }
-    
+
     protected void associateClientV3(OSClientV3 osv3) {
         this.osv3 = osv3;
     }

--- a/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateRecordsetServiceTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateRecordsetServiceTest.java
@@ -1,0 +1,67 @@
+package org.openstack4j.api.dns.v2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.Builders;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.dns.v2.*;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests the DNS/Designate API version 2 ZoneService
+ */
+@Test(groups = "dnsV2", suiteName = "DNS/Designate_V2")
+public class DesignateRecordsetServiceTest extends AbstractTest {
+
+	private static final String JSON_RECORDSET = "/dns/v2/create_recordset.json";
+	private static final String JSON_RECORDSETLIST = "/dns/v2/list_recordsets.json";
+
+	private static final String ZONE_ID = "2150b1bf-dee2-4221-9d85-11f7886fb15f";
+	private static final String RECORDSET_NAME = "example.org.";
+	private static final String RECORDSET_TYPE = "A";
+	private static final ImmutableList<String> RECORDSET_RECORDS = ImmutableList.of("10.1.0.2");
+	private static final Status RECORDSET_STATUS = Status.PENDING;
+	private static final Action RECORDSET_ACTION = Action.CREATE;
+	private static final Integer RECORDSET_VERSION = 1;
+
+	@Override
+	protected Service service() {
+		return Service.DNS;
+	}
+
+	public void recordsetCreateTest() throws Exception {
+
+		respondWith(JSON_RECORDSET);
+
+		Recordset recordset = osv3().dns().recordsets().create(ZONE_ID, RECORDSET_NAME, RECORDSET_TYPE, RECORDSET_RECORDS);
+
+		assertEquals(recordset.getZoneId(), ZONE_ID);
+		assertEquals(recordset.getName(), RECORDSET_NAME);
+		assertEquals(recordset.getType(), RECORDSET_TYPE);
+		assertEquals(recordset.getRecords(), RECORDSET_RECORDS);
+		assertEquals(recordset.getStatus(), RECORDSET_STATUS);
+		assertEquals(recordset.getAction(), RECORDSET_ACTION);
+
+	}
+
+	public void recordsetListTest() throws Exception {
+
+		respondWith(JSON_RECORDSETLIST);
+
+		List<? extends Recordset> recordsetList = osv3().dns().recordsets().list(ZONE_ID);
+
+		assertFalse(recordsetList.isEmpty());
+		assertEquals(recordsetList.get(0).getZoneId(), ZONE_ID);
+		assertEquals(recordsetList.get(0).getVersion(), RECORDSET_VERSION);
+
+	}
+
+}

--- a/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateRecordsetServiceTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateRecordsetServiceTest.java
@@ -1,19 +1,16 @@
 package org.openstack4j.api.dns.v2;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.openstack4j.api.AbstractTest;
-import org.openstack4j.api.Builders;
-import org.openstack4j.model.common.ActionResponse;
-import org.openstack4j.model.dns.v2.*;
+import org.openstack4j.model.dns.v2.Action;
+import org.openstack4j.model.dns.v2.Recordset;
+import org.openstack4j.model.dns.v2.Status;
 import org.testng.annotations.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Tests the DNS/Designate API version 2 ZoneService
@@ -21,47 +18,47 @@ import static org.testng.Assert.assertTrue;
 @Test(groups = "dnsV2", suiteName = "DNS/Designate_V2")
 public class DesignateRecordsetServiceTest extends AbstractTest {
 
-	private static final String JSON_RECORDSET = "/dns/v2/create_recordset.json";
-	private static final String JSON_RECORDSETLIST = "/dns/v2/list_recordsets.json";
+    private static final String JSON_RECORDSET = "/dns/v2/create_recordset.json";
+    private static final String JSON_RECORDSETLIST = "/dns/v2/list_recordsets.json";
 
-	private static final String ZONE_ID = "2150b1bf-dee2-4221-9d85-11f7886fb15f";
-	private static final String RECORDSET_NAME = "example.org.";
-	private static final String RECORDSET_TYPE = "A";
-	private static final ImmutableList<String> RECORDSET_RECORDS = ImmutableList.of("10.1.0.2");
-	private static final Status RECORDSET_STATUS = Status.PENDING;
-	private static final Action RECORDSET_ACTION = Action.CREATE;
-	private static final Integer RECORDSET_VERSION = 1;
+    private static final String ZONE_ID = "2150b1bf-dee2-4221-9d85-11f7886fb15f";
+    private static final String RECORDSET_NAME = "example.org.";
+    private static final String RECORDSET_TYPE = "A";
+    private static final ImmutableList<String> RECORDSET_RECORDS = ImmutableList.of("10.1.0.2");
+    private static final Status RECORDSET_STATUS = Status.PENDING;
+    private static final Action RECORDSET_ACTION = Action.CREATE;
+    private static final Integer RECORDSET_VERSION = 1;
 
-	@Override
-	protected Service service() {
-		return Service.DNS;
-	}
+    @Override
+    protected Service service() {
+        return Service.DNS;
+    }
 
-	public void recordsetCreateTest() throws Exception {
+    public void recordsetCreateTest() throws Exception {
 
-		respondWith(JSON_RECORDSET);
+        respondWith(JSON_RECORDSET);
 
-		Recordset recordset = osv3().dns().recordsets().create(ZONE_ID, RECORDSET_NAME, RECORDSET_TYPE, RECORDSET_RECORDS);
+        Recordset recordset = osv3().dns().recordsets().create(ZONE_ID, RECORDSET_NAME, RECORDSET_TYPE, RECORDSET_RECORDS);
 
-		assertEquals(recordset.getZoneId(), ZONE_ID);
-		assertEquals(recordset.getName(), RECORDSET_NAME);
-		assertEquals(recordset.getType(), RECORDSET_TYPE);
-		assertEquals(recordset.getRecords(), RECORDSET_RECORDS);
-		assertEquals(recordset.getStatus(), RECORDSET_STATUS);
-		assertEquals(recordset.getAction(), RECORDSET_ACTION);
+        assertEquals(recordset.getZoneId(), ZONE_ID);
+        assertEquals(recordset.getName(), RECORDSET_NAME);
+        assertEquals(recordset.getType(), RECORDSET_TYPE);
+        assertEquals(recordset.getRecords(), RECORDSET_RECORDS);
+        assertEquals(recordset.getStatus(), RECORDSET_STATUS);
+        assertEquals(recordset.getAction(), RECORDSET_ACTION);
 
-	}
+    }
 
-	public void recordsetListTest() throws Exception {
+    public void recordsetListTest() throws Exception {
 
-		respondWith(JSON_RECORDSETLIST);
+        respondWith(JSON_RECORDSETLIST);
 
-		List<? extends Recordset> recordsetList = osv3().dns().recordsets().list(ZONE_ID);
+        List<? extends Recordset> recordsetList = osv3().dns().recordsets().list(ZONE_ID);
 
-		assertFalse(recordsetList.isEmpty());
-		assertEquals(recordsetList.get(0).getZoneId(), ZONE_ID);
-		assertEquals(recordsetList.get(0).getVersion(), RECORDSET_VERSION);
+        assertFalse(recordsetList.isEmpty());
+        assertEquals(recordsetList.get(0).getZoneId(), ZONE_ID);
+        assertEquals(recordsetList.get(0).getVersion(), RECORDSET_VERSION);
 
-	}
+    }
 
 }

--- a/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateZoneServiceTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateZoneServiceTest.java
@@ -1,0 +1,87 @@
+package org.openstack4j.api.dns.v2;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.Builders;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.dns.v2.Action;
+import org.openstack4j.model.dns.v2.Status;
+import org.openstack4j.model.dns.v2.Zone;
+import org.openstack4j.model.dns.v2.ZoneType;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests the DNS/Designate API version 2 ZoneService
+ */
+@Test(groups = "dnsV2", suiteName = "DNS/Designate_V2")
+public class DesignateZoneServiceTest extends AbstractTest {
+
+	private static final String JSON_ZONE = "/dns/v2/create_zone.json";
+	private static final String JSON_ZONELIST = "/dns/v2/list_zones.json";
+
+	private static final String ZONE_NAME = "example.org.";
+	private static final String ZONE_EMAIL = "joe@example.org";
+	private static final Status ZONE_STATUS = Status.ACTIVE;
+	private static final Action ZONE_ACTION = Action.CREATE;
+	private static final ZoneType ZONE_TYPE = ZoneType.PRIMARY;
+	private static final Integer ZONE_TTL = 7200;
+	private static final String ZONE_ID = "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3";
+	private static final String ZONE_DESCRIPTION = "This is an example zone.";
+	private static final String ZONE_PROJECT_ID = "4335d1f0-f793-11e2-b778-0800200c9a66";
+
+	@Override
+	protected Service service() {
+		return Service.DNS;
+	}
+
+	public void zoneCreateTest() throws Exception {
+
+		respondWith(JSON_ZONE);
+
+		Zone zone = osv3().dns().zones().create(ZONE_NAME, ZONE_EMAIL);
+
+		assertEquals(zone.getName(), ZONE_NAME);
+		assertEquals(zone.getEmail(), ZONE_EMAIL);
+		assertEquals(zone.getStatus(), ZONE_STATUS);
+		assertEquals(zone.getAction(), ZONE_ACTION);
+		assertEquals(zone.getType(), ZONE_TYPE);
+		assertEquals(zone.getTTL(), ZONE_TTL);
+
+	}
+
+	public void zoneUpdateTest() throws Exception {
+
+		respondWith(JSON_ZONE);
+
+		Zone zone = osv3().dns().zones().update(Builders.dnsV2().zone().id(ZONE_ID).description(ZONE_DESCRIPTION).build());
+
+		assertEquals(zone.getId(), ZONE_ID);
+		assertEquals(zone.getDescription(), ZONE_DESCRIPTION);
+
+	}
+
+	public void zoneListTest() throws Exception {
+
+		respondWith(JSON_ZONELIST);
+
+		List<? extends Zone> zoneList = osv3().dns().zones().list();
+
+		assertFalse(zoneList.isEmpty());
+		assertEquals(zoneList.get(0).getProjectId(),ZONE_PROJECT_ID);
+	}
+
+	public void zoneDeleteTest() throws Exception {
+
+		respondWith(204);
+
+		ActionResponse zoneDeleteResponse = osv3().dns().zones().delete(ZONE_ID);
+
+		assertTrue(zoneDeleteResponse.isSuccess());
+	}
+
+}

--- a/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateZoneServiceTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/dns/v2/DesignateZoneServiceTest.java
@@ -11,9 +11,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * Tests the DNS/Designate API version 2 ZoneService
@@ -21,67 +19,67 @@ import static org.testng.Assert.assertTrue;
 @Test(groups = "dnsV2", suiteName = "DNS/Designate_V2")
 public class DesignateZoneServiceTest extends AbstractTest {
 
-	private static final String JSON_ZONE = "/dns/v2/create_zone.json";
-	private static final String JSON_ZONELIST = "/dns/v2/list_zones.json";
+    private static final String JSON_ZONE = "/dns/v2/create_zone.json";
+    private static final String JSON_ZONELIST = "/dns/v2/list_zones.json";
 
-	private static final String ZONE_NAME = "example.org.";
-	private static final String ZONE_EMAIL = "joe@example.org";
-	private static final Status ZONE_STATUS = Status.ACTIVE;
-	private static final Action ZONE_ACTION = Action.CREATE;
-	private static final ZoneType ZONE_TYPE = ZoneType.PRIMARY;
-	private static final Integer ZONE_TTL = 7200;
-	private static final String ZONE_ID = "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3";
-	private static final String ZONE_DESCRIPTION = "This is an example zone.";
-	private static final String ZONE_PROJECT_ID = "4335d1f0-f793-11e2-b778-0800200c9a66";
+    private static final String ZONE_NAME = "example.org.";
+    private static final String ZONE_EMAIL = "joe@example.org";
+    private static final Status ZONE_STATUS = Status.ACTIVE;
+    private static final Action ZONE_ACTION = Action.CREATE;
+    private static final ZoneType ZONE_TYPE = ZoneType.PRIMARY;
+    private static final Integer ZONE_TTL = 7200;
+    private static final String ZONE_ID = "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3";
+    private static final String ZONE_DESCRIPTION = "This is an example zone.";
+    private static final String ZONE_PROJECT_ID = "4335d1f0-f793-11e2-b778-0800200c9a66";
 
-	@Override
-	protected Service service() {
-		return Service.DNS;
-	}
+    @Override
+    protected Service service() {
+        return Service.DNS;
+    }
 
-	public void zoneCreateTest() throws Exception {
+    public void zoneCreateTest() throws Exception {
 
-		respondWith(JSON_ZONE);
+        respondWith(JSON_ZONE);
 
-		Zone zone = osv3().dns().zones().create(ZONE_NAME, ZONE_EMAIL);
+        Zone zone = osv3().dns().zones().create(ZONE_NAME, ZONE_EMAIL);
 
-		assertEquals(zone.getName(), ZONE_NAME);
-		assertEquals(zone.getEmail(), ZONE_EMAIL);
-		assertEquals(zone.getStatus(), ZONE_STATUS);
-		assertEquals(zone.getAction(), ZONE_ACTION);
-		assertEquals(zone.getType(), ZONE_TYPE);
-		assertEquals(zone.getTTL(), ZONE_TTL);
+        assertEquals(zone.getName(), ZONE_NAME);
+        assertEquals(zone.getEmail(), ZONE_EMAIL);
+        assertEquals(zone.getStatus(), ZONE_STATUS);
+        assertEquals(zone.getAction(), ZONE_ACTION);
+        assertEquals(zone.getType(), ZONE_TYPE);
+        assertEquals(zone.getTTL(), ZONE_TTL);
 
-	}
+    }
 
-	public void zoneUpdateTest() throws Exception {
+    public void zoneUpdateTest() throws Exception {
 
-		respondWith(JSON_ZONE);
+        respondWith(JSON_ZONE);
 
-		Zone zone = osv3().dns().zones().update(Builders.dnsV2().zone().id(ZONE_ID).description(ZONE_DESCRIPTION).build());
+        Zone zone = osv3().dns().zones().update(Builders.dnsV2().zone().id(ZONE_ID).description(ZONE_DESCRIPTION).build());
 
-		assertEquals(zone.getId(), ZONE_ID);
-		assertEquals(zone.getDescription(), ZONE_DESCRIPTION);
+        assertEquals(zone.getId(), ZONE_ID);
+        assertEquals(zone.getDescription(), ZONE_DESCRIPTION);
 
-	}
+    }
 
-	public void zoneListTest() throws Exception {
+    public void zoneListTest() throws Exception {
 
-		respondWith(JSON_ZONELIST);
+        respondWith(JSON_ZONELIST);
 
-		List<? extends Zone> zoneList = osv3().dns().zones().list();
+        List<? extends Zone> zoneList = osv3().dns().zones().list();
 
-		assertFalse(zoneList.isEmpty());
-		assertEquals(zoneList.get(0).getProjectId(),ZONE_PROJECT_ID);
-	}
+        assertFalse(zoneList.isEmpty());
+        assertEquals(zoneList.get(0).getProjectId(), ZONE_PROJECT_ID);
+    }
 
-	public void zoneDeleteTest() throws Exception {
+    public void zoneDeleteTest() throws Exception {
 
-		respondWith(204);
+        respondWith(204);
 
-		ActionResponse zoneDeleteResponse = osv3().dns().zones().delete(ZONE_ID);
+        ActionResponse zoneDeleteResponse = osv3().dns().zones().delete(ZONE_ID);
 
-		assertTrue(zoneDeleteResponse.isSuccess());
-	}
+        assertTrue(zoneDeleteResponse.isSuccess());
+    }
 
 }

--- a/core-test/src/main/resources/dns/v2/create_recordset.json
+++ b/core-test/src/main/resources/dns/v2/create_recordset.json
@@ -1,0 +1,21 @@
+{
+  "description": "This is an example record set.",
+  "links": {
+    "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+  },
+  "updated_at": null,
+  "records": [
+    "10.1.0.2"
+  ],
+  "ttl": 3600,
+  "id": "f7b10e9b-0cae-4a91-b162-562bc6096648",
+  "name": "example.org.",
+  "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+  "zone_id": "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+  "zone_name": "example.com.",
+  "created_at": "2014-10-24T19:59:44.000000",
+  "version": 1,
+  "type": "A",
+  "status": "PENDING",
+  "action": "CREATE"
+}

--- a/core-test/src/main/resources/dns/v2/create_zone.json
+++ b/core-test/src/main/resources/dns/v2/create_zone.json
@@ -1,0 +1,21 @@
+{
+  "id": "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
+  "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
+  "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+  "name": "example.org.",
+  "email": "joe@example.org",
+  "ttl": 7200,
+  "serial": 1404757531,
+  "status": "ACTIVE",
+  "action": "CREATE",
+  "description": "This is an example zone.",
+  "masters": [],
+  "type": "PRIMARY",
+  "transferred_at": null,
+  "version": 1,
+  "created_at": "2014-07-07T18:25:31.275934",
+  "updated_at": null,
+  "links": {
+    "self": "https://127.0.0.1:9001/v2/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
+  }
+}

--- a/core-test/src/main/resources/dns/v2/list_recordsets.json
+++ b/core-test/src/main/resources/dns/v2/list_recordsets.json
@@ -1,0 +1,32 @@
+{
+  "recordsets": [
+    {
+      "description": "This is an example record set.",
+      "links": {
+        "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+      },
+      "updated_at": null,
+      "records": [
+        "10.1.0.2"
+      ],
+      "ttl": 3600,
+      "id": "f7b10e9b-0cae-4a91-b162-562bc6096648",
+      "name": "example.org.",
+      "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+      "zone_id": "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+      "zone_name": "example.com.",
+      "created_at": "2014-10-24T19:59:44.000000",
+      "version": 1,
+      "type": "A",
+      "status": "PENDING",
+      "action": "CREATE"
+    }
+  ],
+  "links": {
+    "self": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1",
+    "next": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1&marker=45fd892d-7a67-4f65-9df0-87273f228d6c"
+  },
+  "metadata": {
+    "total_count": 2
+  }
+}

--- a/core-test/src/main/resources/dns/v2/list_zones.json
+++ b/core-test/src/main/resources/dns/v2/list_zones.json
@@ -1,0 +1,32 @@
+{
+  "zones": [
+    {
+      "id": "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
+      "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
+      "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+      "name": "example.org.",
+      "email": "joe@example.org",
+      "ttl": 7200,
+      "serial": 1404757531,
+      "status": "ACTIVE",
+      "action": "CREATE",
+      "description": "This is an example zone.",
+      "masters": [],
+      "type": "PRIMARY",
+      "transferred_at": null,
+      "version": 1,
+      "created_at": "2014-07-07T18:25:31.275934",
+      "updated_at": null,
+      "links": {
+        "self": "https://127.0.0.1:9001/v2/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
+      }
+    }
+  ],
+  "links": {
+    "self": "http://127.0.0.1:9001/v2/zones?limit=1",
+    "next": "http://127.0.0.1:9001/v2/zones?limit=1&marker=45fd892d-7a67-4f65-9df0-87273f228d6c"
+  },
+  "metadata": {
+    "total_count": 2
+  }
+}

--- a/core-test/src/main/resources/identity/v3/authv3_project.json
+++ b/core-test/src/main/resources/identity/v3/authv3_project.json
@@ -1,581 +1,668 @@
 {
-	"token": {
-		"methods": ["password"],
-		"roles": [
-			{
-				"id": "6ead57f8ae124996af8b0beb72ff1007",
-				"name": "admin"
-			}
-		],
-		"expires_at": "2015-08-26T14:14:10.309926Z",
-		"project": {
-			"domain": {
-				"id": "default",
-				"name": "Default"
-			},
-			"id": "123ac695d4db400a9001b91bb3b8aa46",
-			"name": "admin"
-		},
-		"catalog": [
-			{
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9292",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "6e82c8912d3f49a09df51035681d564c"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9292",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "7e44d321ae80457abc3728fa1e6feb32"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9292",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "c9a090a4597040849c03bc13588167f6"
-					}
-				],
-				"type": "image",
-				"id": "0d56500210a24c38a3702b6825e24164",
-				"name": "glance"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9494",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "ab129c85b6bc4d229a5dc21de7400ede"
-					},
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9494",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "c2361ae4f9eb47a9a98928cc9db49ec1"
-					},
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9494",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "f3e9c7f6d3914eedb5fe0f4dc8e53438"
-					}
-				],
-				"type": "artifact",
-				"id": "3a6ea5b1d31943cdb751c4484fa6ee24",
-				"name": "glare"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "261aaf6239bb49a4a1cfa87c19859138"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "437d282e0bb94622aaacc4d194c069a9"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "5e78bf7bae7c4ff5b9720b2c2e4da743"
-					}
-				],
-				"type": "volumev2",
-				"id": "2b92e79c45254516932c633229cd0e8b",
-				"name": "cinderv2"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8773/",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "1ce26a6fffd0424bac135b9c68055b6e"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8773/",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "98db699b9ffa4dffb027d78163aad8cc"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8773/",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "ece52860cf1e4eb6a8fed05c47a30147"
-					}
-				],
-				"type": "ec2",
-				"id": "3364a7b95c664bf89a7a8db081576364",
-				"name": "ec2"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8786/v1/b80f8d4e28b74188858b654cb1fccf7d",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "b80f8d4e28b74188858b654cb1fccf7d"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8786/v1/b80f8d4e28b74188858b654cb1fccf7d",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "b80f8d4e28b74188858b654cb1fccf7d"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8786/v1/b80f8d4e28b74188858b654cb1fccf7d",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "b80f8d4e28b74188858b654cb1fccf7d"
-					}
-				],
-				"endpoints_links": [],
-				"type": "share",
-				"name": "manila"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "4442fbd064844a7bbe6a792507d4b8e3"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "4b4178fd2e3d4f329600cc4ceaaa7e3a"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "90977723dba04ea9a2a184c99565ccff"
-					}
-				],
-				"type": "volume",
-				"id": "511b94ce0482484ea09028091dd5e9a5",
-				"name": "cinder"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "81c51855280345e9a6c322ca986d4e4b"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "a0310a37cf6144a6a967cbae9a7959ba"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "f6d38c03b9c04a9e924aaa288ce014b8"
-					}
-				],
-				"type": "compute",
-				"id": "5b7028751ed045d79467c7845ecb8c58",
-				"name": "nova"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "2f17e155b0aa47838394e6c4f6fe30e0"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "9d2555fd27dd44e5acfb5e56127d974b"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "e8bdd9403fbb4efa8d77bfd4f6a5e34a"
-					}
-				],
-				"type": "computev21",
-				"id": "97e665cbada043718180c5a6316df76a",
-				"name": "novav21"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:35357/v3",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "185eda94de9340e58245062f75d7f80e"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "9abd6797844d455f875af9537325cba4"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "d3b31f24e4ea40699f731e29e625c187"
-					}, {
-						"region_id": "europe",
-						"url": "http://127.0.0.1:35357/v3",
-						"region": "europe",
-						"interface": "admin",
-						"id": "185eda94de9340e58245062f75d7f80e"
-					}, {
-						"region_id": "europe",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "europe",
-						"interface": "internal",
-						"id": "9abd6797844d455f875af9537325cba4"
-					}, {
-						"region_id": "europe",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "europe",
-						"interface": "public",
-						"id": "d3b31f24e4ea40699f731e29e625c187"
-					}
-				],
-				"type": "identity",
-				"id": "b577d8f7c7074d04a1165fcca638b600",
-				"name": "keystone_v3x"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "europe",
-						"url": "http://127.0.0.1:35357/v3",
-						"region": "europe",
-						"interface": "admin",
-						"id": "32bb2c6aea944ea6b4956eb24142d2e2"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "480ea71dc8cf4c959df1c6304be87056"
-					}, {
-						"region_id": "europe",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "europe",
-						"interface": "public",
-						"id": "600638643d22494fad4f30e3b22ae124"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "8a254651925e4a3e9505c863a00c017e"
-					}, {
-						"region_id": "europe",
-						"url": "http://127.0.0.1:5000/v3",
-						"region": "europe",
-						"interface": "internal",
-						"id": "b93da6aaba654d8cb451ff8378d7d2a5"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:35357/v3",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "d5f8e0da0f3345529a5fb324d735d4a3"
-					}
-				],
-				"type": "identity_v3",
-				"id": "cd9002bbadfe495d81b5ee4c50768009",
-				"name": "keystone_v3"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9696",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "6e82c8912d3f49a09df51035681d5678"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9696",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "7e44d321ae80457abc3728fa1e6f1234"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9696",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "c9a090a4597040849c03bc1358854321"
-					}
-				],
-				"type": "network",
-				"id": "0d56500210a24c38a3702b6825e12345",
-				"name": "neutron"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8800",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "123458912d3f49a09df51035681d564c"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8800",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "12345321ae80457abc3728fa1e6feb32"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8800",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "123450a4597040849c03bc13588167f6"
-					}
-				],
-				"type": "Object_Storage",
-				"id": "1234500210a24c38a3702b6825e24164",
-				"name": "swift"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8087",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "123458912d3f49a09df51035681d5678"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8087",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "12345321ae80457abc3728fa1e6f1234"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8087",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "123450a4597040849c03bc1358854321"
-					}
-				],
-				"type": "telemetry",
-				"id": "1236500210a24c38a3702b6825e12345",
-				"name": "ceilometeter"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8082",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "123458912d3f49a09df51035681d6789"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8082",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "12345321ae80457abc3728fa1e6f4567"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:8082",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "123450a4597040849c03bc1358857654"
-					}
-				],
-				"type": "application-catalog",
-				"id": "1236500210a24c38a3702b6825e56789",
-				"name": "murano"
-			}, {
-				"endpoints": [
-					{
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9511/v1",
-						"region": "RegionOne",
-						"interface": "public",
-						"id": "123458912d3f49a09df51035681d5991"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9511/v1",
-						"region": "RegionOne",
-						"interface": "admin",
-						"id": "123458912d3f49a09df51035681d5992"
-					}, {
-						"region_id": "RegionOne",
-						"url": "http://127.0.0.1:9511/v1",
-						"region": "RegionOne",
-						"interface": "internal",
-						"id": "123458912d3f49a09df51035681d5993"
-					}
-				],
-				"type": "container",
-				"id": "3afa96cf8ff44b03a5f93ec3b1d361c0",
-				"name": "magnum"
-			}, {
-			"endpoints": [
-			  {
-				"region_id": "RegionOne",
-				"url": "http://127.0.0.1:8778",
-				"region": "RegionOne",
-				"interface": "admin",
-				"id": "002ac55c6cf344cc9023d2841b45ffa3"
-			  },
-			  {
-				"region_id": "RegionOne",
-				"url": "http://127.0.0.1:8778",
-				"region": "RegionOne",
-				"interface": "internal",
-				"id": "296b3aafebfb469c8c3154930a5d7548"
-			  },
-			  {
-				"region_id": "RegionOne",
-				"url": "http://127.0.0.1:8778",
-				"region": "RegionOne",
-				"interface": "public",
-				"id": "952f509aa8ce4e2ba46d59e0e52e2e46"
-			  }
-			],
-			"type": "clustering",
-			"id": "1fafaecc7eb2475fb2cf50d420f88cfa",
-			"name": "senlin"
-		  }, {
-			"endpoints": [
-			  {
-				"region_id": "RegionOne",
-				"url": "http://127.0.0.1:8779/v1.0/26decac97b67478f9f64ff2c2c1b778e",
-				"region": "RegionOne",
-				"interface": "admin",
-				"id": "7202c1c716f74468b6d22a1a5f83e38d"
-			  }, {
-				"region_id": "RegionOne",
-				"url": "http://127.0.0.1:8779/v1.0/26decac97b67478f9f64ff2c2c1b778e",
-				"region": "RegionOne",
-				"interface": "internal",
-				"id": "373cf9b0185c4406bd7cae1a1e9e1b95"
-			  }, {
-				"region_id": "RegionOne",
-				"url": "http://127.0.0.1:8779/v1.0/26decac97b67478f9f64ff2c2c1b778e",
-				"region": "RegionOne",
-				"interface": "public",
-				"id": "58bc7c3c2c66464b99ec20a398492bce"
-			  }
-			],
-			"type": "database",
-			"id": "511b94ce0482484ea09028091dd5e9a5",
-			"name": "trove"
-		  }, {
-			"endpoints": [
-				{
-					"region_id": "RegionOne",
-					"url": "http://127.0.0.1:9311",
-					"region": "RegionOne",
-					"interface": "admin",
-					"id": "002ac55c6cf344cc9023d2841b45ffa9"
-				},
-				{
-					"region_id": "RegionOne",
-					"url": "http://127.0.0.1:9311",
-					"region": "RegionOne",
-					"interface": "internal",
-					"id": "002ac55c6cf344cc9023d2841b45ffa8"
-				},
-				{
-					"region_id": "RegionOne",
-					"url": "http://127.0.0.1:9311",
-					"region": "RegionOne",
-					"interface": "public",
-					"id": "002ac55c6cf344cc9023d2841b45ffa7"
-				}
-			],
-			"type": "key-manager",
-			"id": "002ac55c6cf344cc9023d2841b45ffa6",
-			"name": "barbican"
-		  }, {
-            "endpoints": [
-                {
-                    "region_id": "RegionOne",
-                    "url": "http://127.0.0.1:8004",
-                    "region": "RegionOne",
-                    "interface": "admin",
-                    "id": "002ac55c6cf344cc9023d2841b45ffa9"
-                },
-                {
-                    "region_id": "RegionOne",
-                    "url": "http://127.0.0.1:8004",
-                    "region": "RegionOne",
-                    "interface": "internal",
-                    "id": "002ac55c6cf344cc9023d2841b45ffa8"
-                },
-                {
-                    "region_id": "RegionOne",
-                    "url": "http://127.0.0.1:8004",
-                    "region": "RegionOne",
-                    "interface": "public",
-                    "id": "002ac55c6cf344cc9023d2841b45ffa7"
-                }
-            ],
-            "type": "orchestration",
-            "id": "002ac55c6cf344cc9023d2841b45ffa6",
-            "name": "heat"
-			}, {
-		  "endpoints": [
-		    {
-		      "region_id": "RegionOne",
-		      "url": "http://127.0.0.1:9890",
-		      "region": "RegionOne",
-		      "interface": "admin",
-		      "id": "0c2f6e9ed7bd499ba445103cb91e80da"
-		    },
-		    {
-		      "region_id": "RegionOne",
-		      "url": "http://127.0.0.1:9890",
-		      "region": "RegionOne",
-		      "interface": "public",
-		      "id": "5328f25a0e584ba392fa5cac3e9b6ee6"
-		    },
-		    {
-		      "region_id": "RegionOne",
-		      "url": "http://127.0.0.1:9890",
-		      "region": "RegionOne",
-		      "interface": "internal",
-		      "id": "c1f3e92aa5284fd999a113502ba4052d"
-		    }
-		  ],
-		  "type": "nfv-orchestration",
-		  "id": "83dd97cc45b7417886ad4940189b2b86",
-		  "name": "tacker"
-		 }
-		],
-		"extras": {},
-		"user": {
-			"domain": {
-				"id": "default",
-				"name": "Default"
-			},
-			"id": "aa9f25defa6d4cafb48466df83106065",
-			"name": "admin"
-		},
-		"audit_ids": ["vBLvL_eKRMi3eJQ-f1I1AQ"],
-		"issued_at": "2015-08-26T13:14:10.309982Z"
-	}
+  "token": {
+    "methods": [
+      "password"
+    ],
+    "roles": [
+      {
+        "id": "6ead57f8ae124996af8b0beb72ff1007",
+        "name": "admin"
+      }
+    ],
+    "expires_at": "2015-08-26T14:14:10.309926Z",
+    "project": {
+      "domain": {
+        "id": "default",
+        "name": "Default"
+      },
+      "id": "123ac695d4db400a9001b91bb3b8aa46",
+      "name": "admin"
+    },
+    "catalog": [
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9001",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "6e82c8912d3f49a09df51035681d564c"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9001",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "7e44d321ae80457abc3728fa1e6feb32"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9001",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "c9a090a4597040849c03bc13588167f6"
+          }
+        ],
+        "type": "dns",
+        "id": "0d56500210a24c38a3702b6825e24164",
+        "name": "designate"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9292",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "6e82c8912d3f49a09df51035681d564c"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9292",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "7e44d321ae80457abc3728fa1e6feb32"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9292",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "c9a090a4597040849c03bc13588167f6"
+          }
+        ],
+        "type": "image",
+        "id": "0d56500210a24c38a3702b6825e24164",
+        "name": "glance"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9494",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "ab129c85b6bc4d229a5dc21de7400ede"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9494",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "c2361ae4f9eb47a9a98928cc9db49ec1"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9494",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "f3e9c7f6d3914eedb5fe0f4dc8e53438"
+          }
+        ],
+        "type": "artifact",
+        "id": "3a6ea5b1d31943cdb751c4484fa6ee24",
+        "name": "glare"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "261aaf6239bb49a4a1cfa87c19859138"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "437d282e0bb94622aaacc4d194c069a9"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "5e78bf7bae7c4ff5b9720b2c2e4da743"
+          }
+        ],
+        "type": "volumev2",
+        "id": "2b92e79c45254516932c633229cd0e8b",
+        "name": "cinderv2"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8773/",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "1ce26a6fffd0424bac135b9c68055b6e"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8773/",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "98db699b9ffa4dffb027d78163aad8cc"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8773/",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "ece52860cf1e4eb6a8fed05c47a30147"
+          }
+        ],
+        "type": "ec2",
+        "id": "3364a7b95c664bf89a7a8db081576364",
+        "name": "ec2"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8786/v1/b80f8d4e28b74188858b654cb1fccf7d",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "b80f8d4e28b74188858b654cb1fccf7d"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8786/v1/b80f8d4e28b74188858b654cb1fccf7d",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "b80f8d4e28b74188858b654cb1fccf7d"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8786/v1/b80f8d4e28b74188858b654cb1fccf7d",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "b80f8d4e28b74188858b654cb1fccf7d"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "share",
+        "name": "manila"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "4442fbd064844a7bbe6a792507d4b8e3"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "4b4178fd2e3d4f329600cc4ceaaa7e3a"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "90977723dba04ea9a2a184c99565ccff"
+          }
+        ],
+        "type": "volume",
+        "id": "511b94ce0482484ea09028091dd5e9a5",
+        "name": "cinder"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "81c51855280345e9a6c322ca986d4e4b"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "a0310a37cf6144a6a967cbae9a7959ba"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "f6d38c03b9c04a9e924aaa288ce014b8"
+          }
+        ],
+        "type": "compute",
+        "id": "5b7028751ed045d79467c7845ecb8c58",
+        "name": "nova"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "2f17e155b0aa47838394e6c4f6fe30e0"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "9d2555fd27dd44e5acfb5e56127d974b"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "e8bdd9403fbb4efa8d77bfd4f6a5e34a"
+          }
+        ],
+        "type": "computev21",
+        "id": "97e665cbada043718180c5a6316df76a",
+        "name": "novav21"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:35357/v3",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "185eda94de9340e58245062f75d7f80e"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "9abd6797844d455f875af9537325cba4"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "d3b31f24e4ea40699f731e29e625c187"
+          },
+          {
+            "region_id": "europe",
+            "url": "http://127.0.0.1:35357/v3",
+            "region": "europe",
+            "interface": "admin",
+            "id": "185eda94de9340e58245062f75d7f80e"
+          },
+          {
+            "region_id": "europe",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "europe",
+            "interface": "internal",
+            "id": "9abd6797844d455f875af9537325cba4"
+          },
+          {
+            "region_id": "europe",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "europe",
+            "interface": "public",
+            "id": "d3b31f24e4ea40699f731e29e625c187"
+          }
+        ],
+        "type": "identity",
+        "id": "b577d8f7c7074d04a1165fcca638b600",
+        "name": "keystone_v3x"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "europe",
+            "url": "http://127.0.0.1:35357/v3",
+            "region": "europe",
+            "interface": "admin",
+            "id": "32bb2c6aea944ea6b4956eb24142d2e2"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "480ea71dc8cf4c959df1c6304be87056"
+          },
+          {
+            "region_id": "europe",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "europe",
+            "interface": "public",
+            "id": "600638643d22494fad4f30e3b22ae124"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "8a254651925e4a3e9505c863a00c017e"
+          },
+          {
+            "region_id": "europe",
+            "url": "http://127.0.0.1:5000/v3",
+            "region": "europe",
+            "interface": "internal",
+            "id": "b93da6aaba654d8cb451ff8378d7d2a5"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:35357/v3",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "d5f8e0da0f3345529a5fb324d735d4a3"
+          }
+        ],
+        "type": "identity_v3",
+        "id": "cd9002bbadfe495d81b5ee4c50768009",
+        "name": "keystone_v3"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9696",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "6e82c8912d3f49a09df51035681d5678"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9696",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "7e44d321ae80457abc3728fa1e6f1234"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9696",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "c9a090a4597040849c03bc1358854321"
+          }
+        ],
+        "type": "network",
+        "id": "0d56500210a24c38a3702b6825e12345",
+        "name": "neutron"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8800",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "123458912d3f49a09df51035681d564c"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8800",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "12345321ae80457abc3728fa1e6feb32"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8800",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "123450a4597040849c03bc13588167f6"
+          }
+        ],
+        "type": "Object_Storage",
+        "id": "1234500210a24c38a3702b6825e24164",
+        "name": "swift"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "123458912d3f49a09df51035681d5678"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "12345321ae80457abc3728fa1e6f1234"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "123450a4597040849c03bc1358854321"
+          }
+        ],
+        "type": "telemetry",
+        "id": "1236500210a24c38a3702b6825e12345",
+        "name": "ceilometeter"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8082",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "123458912d3f49a09df51035681d6789"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8082",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "12345321ae80457abc3728fa1e6f4567"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8082",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "123450a4597040849c03bc1358857654"
+          }
+        ],
+        "type": "application-catalog",
+        "id": "1236500210a24c38a3702b6825e56789",
+        "name": "murano"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9511/v1",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "123458912d3f49a09df51035681d5991"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9511/v1",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "123458912d3f49a09df51035681d5992"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9511/v1",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "123458912d3f49a09df51035681d5993"
+          }
+        ],
+        "type": "container",
+        "id": "3afa96cf8ff44b03a5f93ec3b1d361c0",
+        "name": "magnum"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8778",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "002ac55c6cf344cc9023d2841b45ffa3"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8778",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "296b3aafebfb469c8c3154930a5d7548"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8778",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "952f509aa8ce4e2ba46d59e0e52e2e46"
+          }
+        ],
+        "type": "clustering",
+        "id": "1fafaecc7eb2475fb2cf50d420f88cfa",
+        "name": "senlin"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8779/v1.0/26decac97b67478f9f64ff2c2c1b778e",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "7202c1c716f74468b6d22a1a5f83e38d"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8779/v1.0/26decac97b67478f9f64ff2c2c1b778e",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "373cf9b0185c4406bd7cae1a1e9e1b95"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8779/v1.0/26decac97b67478f9f64ff2c2c1b778e",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "58bc7c3c2c66464b99ec20a398492bce"
+          }
+        ],
+        "type": "database",
+        "id": "511b94ce0482484ea09028091dd5e9a5",
+        "name": "trove"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9311",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "002ac55c6cf344cc9023d2841b45ffa9"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9311",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "002ac55c6cf344cc9023d2841b45ffa8"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9311",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "002ac55c6cf344cc9023d2841b45ffa7"
+          }
+        ],
+        "type": "key-manager",
+        "id": "002ac55c6cf344cc9023d2841b45ffa6",
+        "name": "barbican"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8004",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "002ac55c6cf344cc9023d2841b45ffa9"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8004",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "002ac55c6cf344cc9023d2841b45ffa8"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8004",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "002ac55c6cf344cc9023d2841b45ffa7"
+          }
+        ],
+        "type": "orchestration",
+        "id": "002ac55c6cf344cc9023d2841b45ffa6",
+        "name": "heat"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9890",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "0c2f6e9ed7bd499ba445103cb91e80da"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9890",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "5328f25a0e584ba392fa5cac3e9b6ee6"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:9890",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "c1f3e92aa5284fd999a113502ba4052d"
+          }
+        ],
+        "type": "nfv-orchestration",
+        "id": "83dd97cc45b7417886ad4940189b2b86",
+        "name": "tacker"
+      }
+    ],
+    "extras": {},
+    "user": {
+      "domain": {
+        "id": "default",
+        "name": "Default"
+      },
+      "id": "aa9f25defa6d4cafb48466df83106065",
+      "name": "admin"
+    },
+    "audit_ids": [
+      "vBLvL_eKRMi3eJQ-f1I1AQ"
+    ],
+    "issued_at": "2015-08-26T13:14:10.309982Z"
+  }
 }
 

--- a/core/src/main/java/org/openstack4j/api/Apis.java
+++ b/core/src/main/java/org/openstack4j/api/Apis.java
@@ -3,6 +3,7 @@ package org.openstack4j.api;
 import org.openstack4j.api.artifact.ArtifactService;
 import org.openstack4j.api.barbican.BarbicanService;
 import org.openstack4j.api.compute.ComputeService;
+import org.openstack4j.api.dns.v2.DNSService;
 import org.openstack4j.api.gbp.GbpService;
 import org.openstack4j.api.heat.HeatService;
 import org.openstack4j.api.image.ImageService;
@@ -179,7 +180,6 @@ public class Apis {
         return get(MagnumService.class);
     }
 
-
     /**
      * Gets the (BarbicanService) Orchestration services API
      * @return the BarbicanService services
@@ -187,6 +187,13 @@ public class Apis {
     public static BarbicanService getBarbicanServices() {
         return get(BarbicanService.class);
     }
+
+    /**
+     * Gets the dns services API
+     * @return the dns services
+     */
+    public static DNSService getDNSService() { return get(DNSService.class); }
+
 
     private static APIProvider initializeProvider() {
         // No need to check for emptiness as there is default implementation registered

--- a/core/src/main/java/org/openstack4j/api/Builders.java
+++ b/core/src/main/java/org/openstack4j/api/Builders.java
@@ -6,6 +6,9 @@ import org.openstack4j.model.barbican.builder.ContainerCreateBuilder;
 import org.openstack4j.model.barbican.builder.ContainerSecretBuilder;
 import org.openstack4j.model.common.builder.LinkBuilder;
 import org.openstack4j.model.compute.builder.*;
+import org.openstack4j.model.dns.v2.builder.DNSV2Builders;
+import org.openstack4j.model.dns.v2.builder.RecordsetBuilder;
+import org.openstack4j.model.dns.v2.builder.ZoneBuilder;
 import org.openstack4j.model.gbp.builder.ExternalPolicyBuilder;
 import org.openstack4j.model.gbp.builder.ExternalRoutesBuilder;
 import org.openstack4j.model.gbp.builder.ExternalSegmentBuilder;
@@ -54,6 +57,9 @@ import org.openstack4j.openstack.compute.builder.NovaBuilders;
 import org.openstack4j.openstack.compute.domain.*;
 import org.openstack4j.openstack.compute.domain.NovaSecGroupExtension.SecurityGroupRule;
 import org.openstack4j.openstack.compute.domain.NovaServerCreate;
+import org.openstack4j.openstack.dns.v2.builder.DesignateV2Builders;
+import org.openstack4j.openstack.dns.v2.domain.DesignateRecordset;
+import org.openstack4j.openstack.dns.v2.domain.DesignateZone;
 import org.openstack4j.openstack.gbp.domain.GbpExternalPolicyCreate;
 import org.openstack4j.openstack.gbp.domain.GbpExternalRoutes;
 import org.openstack4j.openstack.gbp.domain.GbpExternalSegment;
@@ -1160,4 +1166,27 @@ public class Builders {
     public static EnvironmentBuilder environment() {
         return MuranoEnvironment.builder();
     }
+
+    /**
+     * The DNS/Designate V2 builders
+     *
+     * @return the dns/designate v2 builders
+     */
+    public static DNSV2Builders dnsV2() {
+        return new DesignateV2Builders();
+    }
+
+    /**
+     * The builder to create a Zone.
+     *
+     * @return the zone builder
+     */
+    public static ZoneBuilder zone() { return DesignateZone.builder(); }
+
+    /**
+     * The builder to create a Recordset.
+     *
+     * @return the recordset builder
+     */
+    public static RecordsetBuilder recordset() { return DesignateRecordset.builder(); }
 }

--- a/core/src/main/java/org/openstack4j/api/OSClient.java
+++ b/core/src/main/java/org/openstack4j/api/OSClient.java
@@ -3,6 +3,7 @@ package org.openstack4j.api;
 import org.openstack4j.api.artifact.ArtifactService;
 import org.openstack4j.api.barbican.BarbicanService;
 import org.openstack4j.api.compute.ComputeService;
+import org.openstack4j.api.dns.v2.DNSService;
 import org.openstack4j.api.exceptions.RegionEndpointNotFoundException;
 import org.openstack4j.api.gbp.GbpService;
 import org.openstack4j.api.heat.HeatService;
@@ -313,5 +314,12 @@ public interface OSClient< T extends OSClient<T>> {
      * @return the Barbican service
      */
     BarbicanService barbican();
+
+    /**
+     * Returns the DNS Service API
+     *
+     * @return the DNS service
+     */
+    DNSService dns();
 
 }

--- a/core/src/main/java/org/openstack4j/api/dns/v2/DNSService.java
+++ b/core/src/main/java/org/openstack4j/api/dns/v2/DNSService.java
@@ -1,0 +1,25 @@
+package org.openstack4j.api.dns.v2;
+
+import org.openstack4j.common.RestService;
+
+/**
+ * DNS/Designate Service Operations API
+ *
+ */
+public interface DNSService extends RestService {
+
+	/**
+	 * Zone Service API
+	 *
+	 * @return the zone service
+	 */
+	ZoneService zones();
+
+	/**
+	 * Recordset Service API
+	 *
+	 * @return the recordsets service
+	 */
+	RecordsetService recordsets();
+
+}

--- a/core/src/main/java/org/openstack4j/api/dns/v2/RecordsetService.java
+++ b/core/src/main/java/org/openstack4j/api/dns/v2/RecordsetService.java
@@ -1,0 +1,79 @@
+package org.openstack4j.api.dns.v2;
+
+import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.dns.v2.Recordset;
+
+import java.util.List;
+
+
+/**
+ * Designate V2 Recordset Service
+ *
+ */
+public interface RecordsetService extends RestService {
+
+	/**
+	 * create a new recordset
+	 *
+	 * @param zoneId the identifier of the zone
+	 * @param recordSet the Recordset
+	 * @return the newly created Recordset
+	 */
+	Recordset create(String zoneId, Recordset recordSet);
+
+	/**
+	 * create a new recordset
+	 *
+	 * @param zoneId the identifier for the zone
+	 * @param name the DNS name for the recordset
+	 * @param type the RRTYPE of the recordset
+	 * @param records a list of data for this recordset. Each item will be a separate record in Designate These items should conform to the DNS spec for the record type - e.g. A records must be IPv4 addresses, CNAME records must be a hostname.
+	 *
+	 * @return the newly created Recordset
+	 */
+	Recordset create(String zoneId, String name, String type, List<String> records);
+
+	/**
+	 * gets detailed information about a specified recordset in a zone by id
+	 *
+	 * @param zoneId the uui of the zone
+	 * @param recordsetId the uuid of the recordset
+	 * @return the recordset
+	 */
+	Recordset get(String zoneId, String recordsetId);
+
+	/**
+	 * updates an existing recordset
+	 *
+	 * @param zoneId the identifier of the zone
+	 * @param recordset the recordset set to update
+	 * @return the updated recordset
+	 */
+	Recordset update(String zoneId, Recordset recordset);
+
+	/**
+	 * delete a recordset within a zone
+	 *
+	 * @param zoneId the uuid of the zone
+	 * @param recordsetId the uuid of the recordset
+	 * @return the action response
+	 */
+	ActionResponse delete(String zoneId, String recordsetId);
+
+	/**
+	 * list all recordsets owned by project
+	 *
+	 * @return list of recordsets
+	 */
+	List<? extends Recordset> list();
+
+	/**
+	 * list recordsets in a zone
+	 *
+	 * @param zoneId the identifier of the zone
+	 * @return list of recordsets in a zone
+	 */
+	List<? extends Recordset> list(String zoneId);
+
+}

--- a/core/src/main/java/org/openstack4j/api/dns/v2/ZoneService.java
+++ b/core/src/main/java/org/openstack4j/api/dns/v2/ZoneService.java
@@ -1,0 +1,73 @@
+package org.openstack4j.api.dns.v2;
+
+import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.dns.v2.Nameserver;
+import org.openstack4j.model.dns.v2.Zone;
+
+import java.util.List;
+
+/**
+ * Designate V2 Zone Service
+ *
+ */
+public interface ZoneService extends RestService {
+
+    /**
+     * create a new zone
+     *
+     * @param zone the zone
+     * @return the newly created zone
+     */
+    Zone create(Zone zone);
+
+    /**
+     * creates a new zone
+     *
+     * @param name the zone name
+     * @param email the e-mail for the zone
+     *
+     * @return the newly created group
+     */
+    Zone create(String name, String email);
+
+    /**
+     * gets detailed information about a specified zone by id
+     *
+     * @param zoneId the zone identifier
+     * @return the zone
+     */
+    Zone get(String zoneId);
+
+    /**
+     * updates an existing zone
+     *
+     * @param zone the zone set to update
+     * @return the updated zone
+     */
+    Zone update(Zone zone);
+
+    /**
+     * delete a zone by id
+     *
+     * @param zoneId the zone id
+     * @return the action response
+     */
+    ActionResponse delete(String zoneId);
+
+    /**
+     * list nameservers for a zone
+     *
+     * @param zoneId the zone identifier
+     * @return list of nameservers for a zone
+     */
+    List<? extends Nameserver> listNameservers(String zoneId);
+
+    /**
+     * lists zones.
+     *
+     * @return list of zones
+     */
+    List<? extends Zone> list();
+
+}

--- a/core/src/main/java/org/openstack4j/api/types/ServiceType.java
+++ b/core/src/main/java/org/openstack4j/api/types/ServiceType.java
@@ -21,6 +21,7 @@ public enum ServiceType {
 	TACKER("tacker", "nfv-orchestration"),
 	ARTIFACT("glare", "artifact"),
     MAGNUM("magnum", "container"),
+	DNS("designate", "dns"),
 	UNKNOWN("NA", "NA")
 	;
 

--- a/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
+++ b/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
@@ -7,60 +7,65 @@ package org.openstack4j.core.transport;
  */
 public final class ClientConstants {
 
-    public static final String HEADER_X_AUTH_TOKEN = "X-Auth-Token";
-    public static final String HEADER_X_SUBJECT_TOKEN = "X-Subject-Token";
-    public static final String HEADER_CONTENT_LANGUAGE = "Content-Language";
-    public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
-    public static final String HEADER_CONTENT_TYPE = "Content-Type";
-    public static final String HEADER_OS4J_AUTH = "OS4J-Auth-Command";
-    public static final String HEADER_ACCEPT = "Accept";
-    public static final String HEADER_USER_AGENT = "User-Agent";
-    public static final String USER_AGENT = "OpenStack4j / OpenStack Client";
+	public static final String HEADER_X_AUTH_TOKEN = "X-Auth-Token";
+	public static final String HEADER_X_SUBJECT_TOKEN = "X-Subject-Token";
+	public static final String HEADER_CONTENT_LANGUAGE = "Content-Language";
+	public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
+	public static final String HEADER_CONTENT_TYPE = "Content-Type";
+	public static final String HEADER_OS4J_AUTH = "OS4J-Auth-Command";
+	public static final String HEADER_ACCEPT = "Accept";
+	public static final String HEADER_USER_AGENT = "User-Agent";
+	public static final String USER_AGENT = "OpenStack4j / OpenStack Client";
 
-    public static final String CONTENT_TYPE_JSON = "application/json";
-    public static final String CONTENT_TYPE_STREAM = "application/stream";
-    public static final String CONTENT_TYPE_DIRECTORY = "application/directory";
-    public static final String CONTENT_TYPE_OCTECT_STREAM = "application/octet-stream";
-    public static final String CONTENT_TYPE_TEXT = "text/plain";
-    public static final String CONTENT_TYPE_TEXT_HTML = "text/html";
-    public static final String CONTENT_TYPE_IMAGE_V2_PATCH = "application/openstack-images-v2.1-json-patch";
-    public static final String CONTENT_TYPE_ARTIFACT_PATCH = "application/json-patch+json";
-    
-    public static final String X_OPENSTACK_REQUEST_ID = "x-openstack-request-id";
+	public static final String CONTENT_TYPE_JSON = "application/json";
+	public static final String CONTENT_TYPE_STREAM = "application/stream";
+	public static final String CONTENT_TYPE_DIRECTORY = "application/directory";
+	public static final String CONTENT_TYPE_OCTECT_STREAM = "application/octet-stream";
+	public static final String CONTENT_TYPE_TEXT = "text/plain";
+	public static final String CONTENT_TYPE_TEXT_HTML = "text/html";
+	public static final String CONTENT_TYPE_IMAGE_V2_PATCH = "application/openstack-images-v2.1-json-patch";
+	public static final String CONTENT_TYPE_ARTIFACT_PATCH = "application/json-patch+json";
+
+	public static final String X_OPENSTACK_REQUEST_ID = "x-openstack-request-id";
 	public static final String X_COMPUTE_REQUEST_ID = "X-Compute-Request-Id";
 
 
-    // Paths
-    public static final String URI_SEP = "/";
-    public static final String PATH_PROJECTS = "/projects";
-    public static final String PATH_ROLES = "/roles";
-    public static final String PATH_USERS = "/users";
-    public static final String PATH_SERVICES = "/services";
-    public static final String PATH_DOMAINS = "/domains";
-    public static final String PATH_ENDPOINTS = "/endpoints";
-    public static final String PATH_EXTENSIONS = "/extensions";
-    public static final String PATH_GROUPS = "/groups";
-    public static final String PATH_POLICIES = "/policies";
-    public static final String PATH_REGIONS = "/regions";
-    public static final String PATH_CREDENTIALS = "/credentials";
-    public static final String PATH_TOKENS = "/auth/tokens";
-    public static final String PATH_PROJECT_SCOPES = "auth/projects";
-    public static final String PATH_DOMAIN_SCOPES = "auth/domains";
-    public static final String PATH_SERVICE_CATALOGS = "auth/catalog";
-    public static final String PATH_TENANTS = "/tenants";
-    public static final String PATH_ARTIFACTS = "/artifacts";
-	
+	// Paths
+	public static final String URI_SEP = "/";
+	public static final String PATH_PROJECTS = "/projects";
+	public static final String PATH_ROLES = "/roles";
+	public static final String PATH_USERS = "/users";
+	public static final String PATH_SERVICES = "/services";
+	public static final String PATH_DOMAINS = "/domains";
+	public static final String PATH_ENDPOINTS = "/endpoints";
+	public static final String PATH_EXTENSIONS = "/extensions";
+	public static final String PATH_GROUPS = "/groups";
+	public static final String PATH_POLICIES = "/policies";
+	public static final String PATH_REGIONS = "/regions";
+	public static final String PATH_CREDENTIALS = "/credentials";
+	public static final String PATH_TOKENS = "/auth/tokens";
+	public static final String PATH_PROJECT_SCOPES = "auth/projects";
+	public static final String PATH_DOMAIN_SCOPES = "auth/domains";
+	public static final String PATH_SERVICE_CATALOGS = "auth/catalog";
+	public static final String PATH_TENANTS = "/tenants";
+	public static final String PATH_ARTIFACTS = "/artifacts";
+
+	// DNS/Designate
+	public static final String PATH_ZONES = "/zones";
+	public static final String PATH_RECORDSETS = "/recordsets";
+	public static final String PATH_NAMESERVERS = "/nameservers";
+
 	//Magnum APIs
-    // list all Magnum Services
-    public static final String MAGNUM_MSERVICES = "/mservices";
-    // list baymodels
-    public static final String MAGNUM_BAYMODELS = "/baymodels";
-    // bays
-    public static final String MAGNUM_BAYS = "/bays";
-    public static final String MAGNUM_CONTAINERS = "/containers";
-    public static final String MAGNUM_CERTIFICATES = "/certificates";
-    public static final String MAGNUM_CLUSTERS = "/clusters";
-    public static final String MAGNUM_CLUSTERTEMPLATES = "/clustertemplates";
-    public static final String MAGNUM_PODS = "/pods";
+	// list all Magnum Services
+	public static final String MAGNUM_MSERVICES = "/mservices";
+	// list baymodels
+	public static final String MAGNUM_BAYMODELS = "/baymodels";
+	// bays
+	public static final String MAGNUM_BAYS = "/bays";
+	public static final String MAGNUM_CONTAINERS = "/containers";
+	public static final String MAGNUM_CERTIFICATES = "/certificates";
+	public static final String MAGNUM_CLUSTERS = "/clusters";
+	public static final String MAGNUM_CLUSTERTEMPLATES = "/clustertemplates";
+	public static final String MAGNUM_PODS = "/pods";
 
 }

--- a/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
+++ b/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
@@ -7,65 +7,65 @@ package org.openstack4j.core.transport;
  */
 public final class ClientConstants {
 
-	public static final String HEADER_X_AUTH_TOKEN = "X-Auth-Token";
-	public static final String HEADER_X_SUBJECT_TOKEN = "X-Subject-Token";
-	public static final String HEADER_CONTENT_LANGUAGE = "Content-Language";
-	public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
-	public static final String HEADER_CONTENT_TYPE = "Content-Type";
-	public static final String HEADER_OS4J_AUTH = "OS4J-Auth-Command";
-	public static final String HEADER_ACCEPT = "Accept";
-	public static final String HEADER_USER_AGENT = "User-Agent";
-	public static final String USER_AGENT = "OpenStack4j / OpenStack Client";
+    public static final String HEADER_X_AUTH_TOKEN = "X-Auth-Token";
+    public static final String HEADER_X_SUBJECT_TOKEN = "X-Subject-Token";
+    public static final String HEADER_CONTENT_LANGUAGE = "Content-Language";
+    public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
+    public static final String HEADER_CONTENT_TYPE = "Content-Type";
+    public static final String HEADER_OS4J_AUTH = "OS4J-Auth-Command";
+    public static final String HEADER_ACCEPT = "Accept";
+    public static final String HEADER_USER_AGENT = "User-Agent";
+    public static final String USER_AGENT = "OpenStack4j / OpenStack Client";
 
-	public static final String CONTENT_TYPE_JSON = "application/json";
-	public static final String CONTENT_TYPE_STREAM = "application/stream";
-	public static final String CONTENT_TYPE_DIRECTORY = "application/directory";
-	public static final String CONTENT_TYPE_OCTECT_STREAM = "application/octet-stream";
-	public static final String CONTENT_TYPE_TEXT = "text/plain";
-	public static final String CONTENT_TYPE_TEXT_HTML = "text/html";
-	public static final String CONTENT_TYPE_IMAGE_V2_PATCH = "application/openstack-images-v2.1-json-patch";
-	public static final String CONTENT_TYPE_ARTIFACT_PATCH = "application/json-patch+json";
+    public static final String CONTENT_TYPE_JSON = "application/json";
+    public static final String CONTENT_TYPE_STREAM = "application/stream";
+    public static final String CONTENT_TYPE_DIRECTORY = "application/directory";
+    public static final String CONTENT_TYPE_OCTECT_STREAM = "application/octet-stream";
+    public static final String CONTENT_TYPE_TEXT = "text/plain";
+    public static final String CONTENT_TYPE_TEXT_HTML = "text/html";
+    public static final String CONTENT_TYPE_IMAGE_V2_PATCH = "application/openstack-images-v2.1-json-patch";
+    public static final String CONTENT_TYPE_ARTIFACT_PATCH = "application/json-patch+json";
+    
+    public static final String X_OPENSTACK_REQUEST_ID = "x-openstack-request-id";
+    public static final String X_COMPUTE_REQUEST_ID = "X-Compute-Request-Id";
 
-	public static final String X_OPENSTACK_REQUEST_ID = "x-openstack-request-id";
-	public static final String X_COMPUTE_REQUEST_ID = "X-Compute-Request-Id";
 
+    // Paths
+    public static final String URI_SEP = "/";
+    public static final String PATH_PROJECTS = "/projects";
+    public static final String PATH_ROLES = "/roles";
+    public static final String PATH_USERS = "/users";
+    public static final String PATH_SERVICES = "/services";
+    public static final String PATH_DOMAINS = "/domains";
+    public static final String PATH_ENDPOINTS = "/endpoints";
+    public static final String PATH_EXTENSIONS = "/extensions";
+    public static final String PATH_GROUPS = "/groups";
+    public static final String PATH_POLICIES = "/policies";
+    public static final String PATH_REGIONS = "/regions";
+    public static final String PATH_CREDENTIALS = "/credentials";
+    public static final String PATH_TOKENS = "/auth/tokens";
+    public static final String PATH_PROJECT_SCOPES = "auth/projects";
+    public static final String PATH_DOMAIN_SCOPES = "auth/domains";
+    public static final String PATH_SERVICE_CATALOGS = "auth/catalog";
+    public static final String PATH_TENANTS = "/tenants";
+    public static final String PATH_ARTIFACTS = "/artifacts";
 
-	// Paths
-	public static final String URI_SEP = "/";
-	public static final String PATH_PROJECTS = "/projects";
-	public static final String PATH_ROLES = "/roles";
-	public static final String PATH_USERS = "/users";
-	public static final String PATH_SERVICES = "/services";
-	public static final String PATH_DOMAINS = "/domains";
-	public static final String PATH_ENDPOINTS = "/endpoints";
-	public static final String PATH_EXTENSIONS = "/extensions";
-	public static final String PATH_GROUPS = "/groups";
-	public static final String PATH_POLICIES = "/policies";
-	public static final String PATH_REGIONS = "/regions";
-	public static final String PATH_CREDENTIALS = "/credentials";
-	public static final String PATH_TOKENS = "/auth/tokens";
-	public static final String PATH_PROJECT_SCOPES = "auth/projects";
-	public static final String PATH_DOMAIN_SCOPES = "auth/domains";
-	public static final String PATH_SERVICE_CATALOGS = "auth/catalog";
-	public static final String PATH_TENANTS = "/tenants";
-	public static final String PATH_ARTIFACTS = "/artifacts";
+    // DNS/Designate
+    public static final String PATH_ZONES = "/zones";
+    public static final String PATH_RECORDSETS = "/recordsets";
+    public static final String PATH_NAMESERVERS = "/nameservers";
 
-	// DNS/Designate
-	public static final String PATH_ZONES = "/zones";
-	public static final String PATH_RECORDSETS = "/recordsets";
-	public static final String PATH_NAMESERVERS = "/nameservers";
-
-	//Magnum APIs
-	// list all Magnum Services
-	public static final String MAGNUM_MSERVICES = "/mservices";
-	// list baymodels
-	public static final String MAGNUM_BAYMODELS = "/baymodels";
-	// bays
-	public static final String MAGNUM_BAYS = "/bays";
-	public static final String MAGNUM_CONTAINERS = "/containers";
-	public static final String MAGNUM_CERTIFICATES = "/certificates";
-	public static final String MAGNUM_CLUSTERS = "/clusters";
-	public static final String MAGNUM_CLUSTERTEMPLATES = "/clustertemplates";
-	public static final String MAGNUM_PODS = "/pods";
+    //Magnum APIs
+    // list all Magnum Services
+    public static final String MAGNUM_MSERVICES = "/mservices";
+    // list baymodels
+    public static final String MAGNUM_BAYMODELS = "/baymodels";
+    // bays
+    public static final String MAGNUM_BAYS = "/bays";
+    public static final String MAGNUM_CONTAINERS = "/containers";
+    public static final String MAGNUM_CERTIFICATES = "/certificates";
+    public static final String MAGNUM_CLUSTERS = "/clusters";
+    public static final String MAGNUM_CLUSTERTEMPLATES = "/clustertemplates";
+    public static final String MAGNUM_PODS = "/pods";
 
 }

--- a/core/src/main/java/org/openstack4j/model/dns/v2/Action.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/Action.java
@@ -1,0 +1,30 @@
+package org.openstack4j.model.dns.v2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Type of a designate v2 recordset action
+ */
+public enum Action {
+
+	NONE, CREATE, DELETE, UPDATE;
+
+	@JsonValue
+	public String value() {
+		return name().toUpperCase();
+	}
+
+	//default to PRIMARY
+	@JsonCreator
+	public static Action value(String v)
+	{
+		if (v == null) return NONE;
+		try {
+			return valueOf(v.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			return NONE;
+		}
+	}
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/Nameserver.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/Nameserver.java
@@ -1,0 +1,24 @@
+package org.openstack4j.model.dns.v2;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.dns.v2.builder.NameserverBuilder;
+
+/**
+ * Nameserver model
+ *
+ * @see <a href="https://developer.openstack.org/api-ref/dns/">API reference</a>
+ */
+public interface Nameserver extends ModelEntity, Buildable<NameserverBuilder> {
+
+    /**
+     * @return the hostname of the nameserver that the zone should be delegated to
+     */
+    String getHostname();
+
+    /**
+     * @return the priority of the nameserver
+     */
+    Integer getPriority();
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/Recordset.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/Recordset.java
@@ -1,0 +1,92 @@
+package org.openstack4j.model.dns.v2;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.dns.v2.builder.RecordsetBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Recordset model
+ *
+ * @see <a href="https://developer.openstack.org/api-ref/dns/">API reference</a>
+ */
+public interface Recordset extends ModelEntity, Buildable<RecordsetBuilder> {
+
+	/**
+	 * @return id for the recordset
+	 */
+	String getId();
+
+	/**
+	 * @return id for the project that owns the resource
+	 */
+	String getProjectId();
+
+	/**
+	 * @return DNS Name for the recordset
+	 */
+	String getName();
+
+	/**
+	 * @return TTL (Time to Live) for the recordset.
+	 */
+	String getTTL();
+
+	/**
+	 * @return status of the resource
+	 */
+	Status getStatus();
+
+	/**
+	 * @return current action in progress on the resource
+	 */
+	Action getAction();
+
+	/**
+	 * @return id for the zone that contains this recordset
+	 */
+	String getZoneId();
+
+	/**
+	 * @return name of the zone that contains this recordset
+	 */
+	String getZoneName();
+
+	/**
+	 * @return description for this recordset
+	 */
+	String getDescription();
+
+	/**
+	 * @return RRTYPE of the recordset
+	 */
+	String getType();
+
+	/**
+	 * @return version of the resource
+	 */
+	Integer getVersion();
+
+	/**
+	 * @return date / time when resource was created
+	 */
+	String getCreatedAt();
+
+	/**
+	 * @return date / time when resource was last updated
+	 */
+	String getUpdatedAt();
+
+	/**
+	 * @return links to the resource, and other related resources.
+	 */
+	Map<String, String> getLinks();
+
+	/**
+	 * @return list of data for this recordset. Each item will be a separate record in Designate.
+	 */
+	List<String> getRecords();
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/Status.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/Status.java
@@ -1,0 +1,30 @@
+package org.openstack4j.model.dns.v2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Status of a designate v2 recordset
+ */
+public enum Status {
+
+	ERROR, PENDING, ACTIVE;
+
+	@JsonValue
+	public String value() {
+		return name().toUpperCase();
+	}
+
+	//default to PRIMARY
+	@JsonCreator
+	public static Status value(String v)
+	{
+		if (v == null) return ERROR;
+		try {
+			return valueOf(v.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			return ERROR;
+		}
+	}
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/Zone.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/Zone.java
@@ -1,0 +1,102 @@
+package org.openstack4j.model.dns.v2;
+
+import org.openstack4j.common.Buildable;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.dns.v2.builder.ZoneBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Zone model
+ *
+ * @see <a href="https://developer.openstack.org/api-ref/dns/">API reference</a>
+ */
+public interface Zone extends ModelEntity, Buildable<ZoneBuilder> {
+
+    /**
+     * @return the id of the zone
+     */
+    String getId();
+
+    /**
+     * @return id for the pool hosting this zone
+     */
+    String getPoolId();
+
+    /**
+     * @return id for the project that owns the resource
+     */
+    String getProjectId();
+
+    /**
+     * @return DNS Name for the zone
+     */
+    String getName();
+
+    /**
+     * @return e-mail for the zone. Used in SOA records for the zone
+     */
+    String getEmail();
+
+    /**
+     * @return TTL (time to Live) for the zone.
+     */
+    Integer getTTL();
+
+    /**
+     * @return current serial number for the zone
+     */
+    String getSerial();
+
+    /**
+     * @return status of the resource
+     */
+    Status getStatus();
+
+    /**
+     * @return current action in progress on the resource
+     */
+    Action getAction();
+
+    /**
+     * @return description for this zone
+     */
+    String getDescription();
+
+    /**
+     * @return mandatory for secondary zones. The servers to slave from to get DNS information
+     */
+    List<String> getMasters();
+
+    /**
+     * @return type of zone.
+     */
+    ZoneType getType();
+
+    /**
+     * @return for secondary zones. The last time an update was retrieved from the master servers.
+     */
+    String getTransferedAt();
+
+    /**
+     * @return version of the resource
+     */
+    Integer getVersion();
+
+    /**
+     * @return date / time when resource was created
+     */
+    String getCreatedAt();
+
+    /**
+     * @return date / time when resource last updated
+     */
+    String getUpdatedAt();
+
+    /**
+     * @return links to the resource, and other related resources
+     */
+    Map<String, String> getLinks();
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/ZoneType.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/ZoneType.java
@@ -1,0 +1,30 @@
+package org.openstack4j.model.dns.v2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Type of a designate v2 zone
+ */
+public enum ZoneType {
+
+	PRIMARY, SECONDARY;
+
+	@JsonValue
+	public String value() {
+		return name().toUpperCase();
+	}
+
+	//default to PRIMARY
+	@JsonCreator
+	public static ZoneType value(String v)
+	{
+		if (v == null) return PRIMARY;
+		try {
+			return valueOf(v.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			return PRIMARY;
+		}
+	}
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/builder/DNSV2Builders.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/builder/DNSV2Builders.java
@@ -1,0 +1,23 @@
+package org.openstack4j.model.dns.v2.builder;
+
+
+/**
+ * The Designate V2 builders
+ */
+public interface DNSV2Builders {
+
+    /**
+     * The builder to create a Zone.
+     *
+     * @return the zone builder
+     */
+    public ZoneBuilder zone();
+
+    /**
+     * The builder to create a Recordset.
+     *
+     * @return the recordset builder
+     */
+    public RecordsetBuilder recordset();
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/builder/NameserverBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/builder/NameserverBuilder.java
@@ -1,0 +1,21 @@
+package org.openstack4j.model.dns.v2.builder;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.model.dns.v2.Nameserver;
+
+/**
+ * A Builder which creates a designate v2 nameserver
+ */
+public interface NameserverBuilder extends Builder<NameserverBuilder, Nameserver> {
+
+	/**
+	 * @see Nameserver#getHostname()
+	 */
+	NameserverBuilder hostname(String hostname);
+
+	/**
+	 * @see Nameserver#getPriority()
+	 */
+	NameserverBuilder priority(Integer priority);
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/builder/RecordsetBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/builder/RecordsetBuilder.java
@@ -1,0 +1,93 @@
+package org.openstack4j.model.dns.v2.builder;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.model.dns.v2.Recordset;
+import org.openstack4j.model.dns.v2.Action;
+import org.openstack4j.model.dns.v2.Status;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Builder which creates a designate v2 Recordset
+ *
+ *
+ */
+public interface RecordsetBuilder extends Builder<RecordsetBuilder, Recordset> {
+
+	/**
+	 * @see Recordset#getId()
+	 */
+	RecordsetBuilder id(String id);
+
+	/**
+	 * @see Recordset#getProjectId()
+	 */
+	RecordsetBuilder projectId(String projectId);
+
+	/**
+	 * @see Recordset#getName()
+	 */
+	RecordsetBuilder name(String name);
+
+	/**
+	 * @see Recordset#getTTL() ()
+	 */
+	RecordsetBuilder ttl(String ttl);
+
+	/**
+	 * @see Recordset#getStatus()
+	 */
+	RecordsetBuilder status(Status status);
+
+	/**
+	 * @see Recordset#getAction()
+	 */
+	RecordsetBuilder action(Action action);
+
+	/**
+	 * @see Recordset#getZoneId()
+	 */
+	RecordsetBuilder zoneId(String zoneId);
+
+	/**
+	 * @see Recordset#getZoneName()
+	 */
+	RecordsetBuilder zoneName(String zoneName);
+
+	/**
+	 * @see Recordset#getDescription()
+	 */
+	RecordsetBuilder description(String description);
+
+	/**
+	 * @see Recordset#getType()
+	 */
+	RecordsetBuilder type(String type);
+
+	/**
+	 * @see Recordset#getVersion()
+	 */
+	RecordsetBuilder version(Integer version);
+
+	/**
+	 * @see Recordset#getCreatedAt()
+	 */
+	RecordsetBuilder createdAt(String createdAt);
+
+	/**
+	 * @see Recordset#getUpdatedAt()
+	 */
+	RecordsetBuilder updatedAt(String updatedAt);
+
+	/**
+	 * @see Recordset#getLinks()
+	 */
+	RecordsetBuilder links(Map<String, String> links);
+
+	/**
+	 * @see Recordset#getRecords()
+	 */
+	RecordsetBuilder records(List<String> records);
+
+}

--- a/core/src/main/java/org/openstack4j/model/dns/v2/builder/ZoneBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/dns/v2/builder/ZoneBuilder.java
@@ -1,0 +1,104 @@
+package org.openstack4j.model.dns.v2.builder;
+
+import java.util.List;
+import java.util.Map;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.model.dns.v2.Action;
+import org.openstack4j.model.dns.v2.Status;
+import org.openstack4j.model.dns.v2.Zone;
+import org.openstack4j.model.dns.v2.ZoneType;
+
+/**
+ * A Builder which creates a designate v2 Zone
+ *
+ *
+ */
+public interface ZoneBuilder extends Builder<ZoneBuilder, Zone> {
+
+	/**
+	 * @see Zone#getId()
+	 */
+	ZoneBuilder id(String id);
+
+	/**
+	 * @see Zone#getPoolId()
+	 */
+	ZoneBuilder poolId(String poolId);
+
+	/**
+	 * @see Zone#getProjectId()
+	 */
+	ZoneBuilder projectId(String projectId);
+
+	/**
+	 * @see Zone#getName()
+	 */
+	ZoneBuilder name(String name);
+
+	/**
+	 * @see Zone#getEmail() ()
+	 */
+	ZoneBuilder email(String email);
+
+	/**
+	 * @see Zone#getTTL() ()
+	 */
+	ZoneBuilder ttl(Integer ttl);
+
+	/**
+	 * @see Zone#getSerial()
+	 */
+	ZoneBuilder serial(String serial);
+
+	/**
+	 * @see Zone#getStatus()
+	 */
+	ZoneBuilder status(Status status);
+
+	/**
+	 * @see Zone#getAction()
+	 */
+	ZoneBuilder action(Action action);
+
+	/**
+	 * @see Zone#getDescription() ()
+	 */
+	ZoneBuilder description(String description);
+
+	/**
+	 * @see Zone#getMasters()
+	 */
+	ZoneBuilder masters(List<String> masters);
+
+	/**
+	 * @see Zone#getType()
+	 */
+	ZoneBuilder type(ZoneType type);
+
+	/**
+	 * @see Zone#getTransferedAt()
+	 */
+	ZoneBuilder transferredAt(String transferredAt);
+
+	/**
+	 * @see Zone#getVersion()
+	 */
+	ZoneBuilder version(Integer version);
+
+	/**
+	 * @see Zone#getCreatedAt()
+	 */
+	ZoneBuilder createdAt(String createdAt);
+
+	/**
+	 * @see Zone#getUpdatedAt()
+	 */
+	ZoneBuilder updatedAt(String updatedAt);
+
+	/**
+	 * @see Zone#getLinks()
+	 */
+	ZoneBuilder links(Map<String, String> links);
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/builder/DesignateV2Builders.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/builder/DesignateV2Builders.java
@@ -1,0 +1,23 @@
+package org.openstack4j.openstack.dns.v2.builder;
+
+import org.openstack4j.model.dns.v2.builder.DNSV2Builders;
+import org.openstack4j.model.dns.v2.builder.RecordsetBuilder;
+import org.openstack4j.model.dns.v2.builder.ZoneBuilder;
+import org.openstack4j.openstack.dns.v2.domain.DesignateZone;
+import org.openstack4j.openstack.dns.v2.domain.DesignateRecordset;
+
+/**
+ * The Designate V2 Builders
+ */
+public class DesignateV2Builders implements DNSV2Builders {
+
+    private DesignateV2Builders DesignateV2Builders() {
+        return this;
+    }
+
+    @Override
+    public ZoneBuilder zone() { return DesignateZone.builder(); }
+
+    @Override
+    public RecordsetBuilder recordset() { return DesignateRecordset.builder(); }
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/domain/DesignateNameserver.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/domain/DesignateNameserver.java
@@ -1,0 +1,136 @@
+package org.openstack4j.openstack.dns.v2.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import org.openstack4j.model.dns.v2.Nameserver;
+import org.openstack4j.model.dns.v2.builder.NameserverBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import java.util.List;
+
+/**
+ * model class for designate/v2 nameserver
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DesignateNameserver implements Nameserver {
+
+	private static final long serialVersionUID = 1L;
+	private String hostname;
+	private Integer priority;
+
+	/**
+	 * @return the nameserver builder
+	 */
+	public static NameserverBuilder builder() {
+		return new NameserverConcreteBuilder();
+	}
+
+	@Override
+	public NameserverBuilder toBuilder() {
+		return new NameserverConcreteBuilder(this);
+	}
+
+	@Override
+	public String getHostname() {
+		return hostname;
+	}
+
+	@Override
+	public Integer getPriority() {
+		return priority;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return Objects.toStringHelper(this).omitNullValues()
+				.add("hostname", hostname)
+				.add("priority", priority)
+				.toString();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(hostname, priority);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null || getClass() != obj.getClass())
+			return false;
+		DesignateNameserver that = DesignateNameserver.class.cast(obj);
+		return Objects.equal(this.hostname, that.hostname)
+				&& Objects.equal(this.priority, that.priority);
+	}
+
+	public static class NameserverConcreteBuilder implements NameserverBuilder {
+
+		DesignateNameserver model;
+
+		NameserverConcreteBuilder() {
+			this(new DesignateNameserver());
+		}
+
+		NameserverConcreteBuilder(DesignateNameserver model) {
+			this.model = model;
+		}
+
+		@Override
+		public Nameserver build() {
+			return model;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public NameserverBuilder from(Nameserver in) {
+			if (in != null)
+				this.model = (DesignateNameserver) in;
+			return this;
+		}
+
+		/**
+		 * @see DesignateNameserver#getHostname()
+		 */
+		@Override
+		public NameserverBuilder hostname(String hostname) {
+			model.hostname = hostname;
+			return this;
+		}
+
+		/**
+		 * @see DesignateNameserver#getPriority()
+		 */
+		@Override
+		public NameserverBuilder priority(Integer priority) {
+			model.priority = priority;
+			return this;
+		}
+
+	}
+
+	public static class Nameservers extends ListResult<DesignateNameserver> {
+
+		private static final long serialVersionUID = 1L;
+		@JsonProperty("nameservers")
+		protected List<DesignateNameserver> list;
+
+		@Override
+		public List<DesignateNameserver> value() {
+			return list;
+		}
+	}
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/domain/DesignateRecordset.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/domain/DesignateRecordset.java
@@ -1,0 +1,323 @@
+package org.openstack4j.openstack.dns.v2.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import org.openstack4j.model.dns.v2.Recordset;
+import org.openstack4j.model.dns.v2.Action;
+import org.openstack4j.model.dns.v2.Status;
+import org.openstack4j.model.dns.v2.builder.RecordsetBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * zone model class for designate/v2 zone
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DesignateRecordset implements Recordset {
+
+    private static final long serialVersionUID = 1L;
+    private String id;
+    @JsonProperty("project_id")
+    private String projectId;
+    private String name;
+    private String ttl;
+    private Status status;
+    private Action action;
+    @JsonProperty("zone_id")
+    private String zoneId;
+    @JsonProperty("zone_name")
+    private String zoneName;
+    private String description;
+    private String type;
+    private Integer version;
+    @JsonProperty("created_at")
+    private String createdAt;
+    @JsonProperty("updated_at")
+    private String updatedAt;
+    private Map<String,String> links;
+    private List<String> records;
+
+    /**
+     * @return the zone builder
+     */
+    public static RecordsetBuilder builder() {
+        return new RecordsetConcreteBuilder();
+    }
+
+    @Override
+    public RecordsetBuilder toBuilder() {
+        return new RecordsetConcreteBuilder(this);
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getProjectId() {
+        return projectId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getTTL() {
+        return ttl;
+    }
+
+    @Override
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
+    }
+
+    @Override
+    public String getZoneId() {
+        return zoneId;
+    }
+
+    @Override
+    public String getZoneName() {
+        return zoneName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Integer getVersion() {
+        return version;
+    }
+
+    @Override
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @Override
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    @Override
+    public List<String> getRecords() {
+        return records;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues()
+                .add("id", id)
+                .add("projectId", projectId)
+                .add("name", name)
+                .add("ttl", ttl)
+                .add("status", status)
+                .add("action", action)
+                .add("zoneId", zoneId)
+                .add("zoneName", zoneName)
+                .add("description",description)
+                .add("type", type)
+                .add("version", version)
+                .add("createdAt", createdAt)
+                .add("updatedAt", updatedAt)
+                .add("links", links)
+                .toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, projectId, name, ttl, status, action, zoneId, zoneName, description, type, version, createdAt, updatedAt, links);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        DesignateRecordset that = DesignateRecordset.class.cast(obj);
+        return Objects.equal(this.id, that.id)
+                && Objects.equal(this.projectId, that.projectId)
+                && Objects.equal(this.name, that.name)
+                && Objects.equal(this.ttl, that.ttl)
+                && Objects.equal(this.status, that.status)
+                && Objects.equal(this.action, that.action)
+                && Objects.equal(this.zoneId, that.zoneId)
+                && Objects.equal(this.zoneName, that.zoneName)
+                && Objects.equal(this.description, that.description)
+                && Objects.equal(this.type, that.type)
+                && Objects.equal(this.version, that.version)
+                && Objects.equal(this.createdAt, that.createdAt)
+                && Objects.equal(this.updatedAt, that.updatedAt)
+                && Objects.equal(this.links, that.links);
+    }
+
+    public static class RecordsetConcreteBuilder implements RecordsetBuilder {
+
+        DesignateRecordset model;
+
+        RecordsetConcreteBuilder() {
+            this(new DesignateRecordset());
+        }
+
+        RecordsetConcreteBuilder(DesignateRecordset model) {
+            this.model = model;
+        }
+
+        @Override
+        public Recordset build() {
+            return model;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public RecordsetBuilder from(Recordset in) {
+            if (in != null)
+                this.model = (DesignateRecordset) in;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder id(String id) {
+            model.id = id;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder projectId(String projectId) {
+            model.projectId = projectId;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder ttl(String ttl) {
+            model.ttl = ttl;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder status(Status status) {
+            model.status = status;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder action(Action action) {
+            model.action = action;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder zoneId(String zoneId) {
+            model.zoneId = zoneId;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder zoneName(String zoneName) {
+            model.zoneName = zoneName;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder description(String description) {
+            model.description = description;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder type(String type) {
+            model.type = type;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder version(Integer version) {
+            model.version = version;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder createdAt(String createdAt) {
+            model.createdAt = createdAt;
+            return this;
+        }
+
+        @Override
+        public RecordsetBuilder updatedAt(String updatedAt) {
+            model.updatedAt = updatedAt;
+            return this;
+        }
+
+        /**
+         * @see DesignateRecordset#getLinks()
+         */
+        @Override
+        public RecordsetBuilder links(Map<String, String> links) {
+            model.links = links;
+            return this;
+        }
+
+        /**
+         * @see DesignateRecordset#getRecords()
+         */
+        @Override
+        public RecordsetBuilder records(List<String> records) {
+            model.records = records;
+            return this;
+        }
+
+    }
+
+    public static class Recordsets extends ListResult<DesignateRecordset> {
+
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("recordsets")
+        protected List<DesignateRecordset> list;
+
+        @Override
+        public List<DesignateRecordset> value() {
+            return list;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/domain/DesignateZone.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/domain/DesignateZone.java
@@ -1,0 +1,399 @@
+package org.openstack4j.openstack.dns.v2.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import org.openstack4j.model.dns.v2.Action;
+import org.openstack4j.model.dns.v2.Status;
+import org.openstack4j.model.dns.v2.Zone;
+import org.openstack4j.model.dns.v2.ZoneType;
+import org.openstack4j.model.dns.v2.builder.ZoneBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * zone model class for designate/v2 zone
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DesignateZone implements Zone {
+
+    private static final long serialVersionUID = 1L;
+    private String id;
+    @JsonProperty("pool_id")
+    private String poolId;
+    @JsonProperty("project_id")
+    private String projectId;
+    private String name;
+    private String email;
+    private Integer ttl;
+    private String serial;
+    private Status status;
+    private Action action;
+    private String description;
+    private List<String> masters;
+    private ZoneType type;
+    @JsonProperty("tranferred_at")
+    private String transferredAt;
+    private Integer version;
+    @JsonProperty("created_at")
+    private String createdAt;
+    @JsonProperty("updated_at")
+    private String updatedAt;
+    private Map<String, String> links;
+
+    /**
+     * @return the zone builder
+     */
+    public static ZoneBuilder builder() {
+        return new ZoneConcreteBuilder();
+    }
+
+    @Override
+    public ZoneBuilder toBuilder() {
+        return new ZoneConcreteBuilder(this);
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getPoolId() {
+        return poolId;
+    }
+
+    @Override
+    public String getProjectId() {
+        return projectId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public Integer getTTL() {
+        return ttl;
+    }
+
+    @Override
+    public String getSerial() {
+        return serial;
+    }
+
+    @Override
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public List<String> getMasters() {
+        return masters;
+    }
+
+    @Override
+    public ZoneType getType() {
+        return type;
+    }
+
+    @Override
+    public String getTransferedAt() {
+        return transferredAt;
+    }
+
+    @Override
+    public Integer getVersion() {
+        return version;
+    }
+
+    @Override
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @Override
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues()
+                .add("id", id)
+                .add("poolId", poolId)
+                .add("projectId", projectId)
+                .add("name", name)
+                .add("email", email)
+                .add("ttl", ttl)
+                .add("serial", serial)
+                .add("status", status)
+                .add("action", action)
+                .add("description",description)
+                .add("masters", masters)
+                .add("type", type)
+                .add("transferredAt", transferredAt)
+                .add("version", version)
+                .add("createdAt", createdAt)
+                .add("updatedAt", updatedAt)
+                .add("links", links)
+                .toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, poolId, projectId, name, email, ttl, serial, status, action, description, masters, type, transferredAt, version, createdAt, updatedAt);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        DesignateZone that = DesignateZone.class.cast(obj);
+        return Objects.equal(this.id, that.id)
+                && Objects.equal(this.poolId, that.poolId)
+                && Objects.equal(this.projectId, that.projectId)
+                && Objects.equal(this.name, that.name)
+                && Objects.equal(this.email, that.email)
+                && Objects.equal(this.ttl, that.ttl)
+                && Objects.equal(this.serial, that.serial)
+                && Objects.equal(this.status, that.status)
+                && Objects.equal(this.action, that.action)
+                && Objects.equal(this.description, that.description)
+                && Objects.equal(this.masters, that.masters)
+                && Objects.equal(this.type, that.type)
+                && Objects.equal(this.transferredAt, that.transferredAt)
+                && Objects.equal(this.version, that.version)
+                && Objects.equal(this.createdAt, that.createdAt)
+                && Objects.equal(this.updatedAt, that.updatedAt)
+                && Objects.equal(this.links, that.links);
+    }
+
+    public static class ZoneConcreteBuilder implements ZoneBuilder {
+
+        DesignateZone model;
+
+        ZoneConcreteBuilder() {
+            this(new DesignateZone());
+        }
+
+        ZoneConcreteBuilder(DesignateZone model) {
+            this.model = model;
+        }
+
+        @Override
+        public Zone build() {
+            return model;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ZoneBuilder from(Zone in) {
+            if (in != null)
+                this.model = (DesignateZone) in;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getId()
+         */
+        @Override
+        public ZoneBuilder id(String id) {
+            model.id = id;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getPoolId()
+         */
+        @Override
+        public ZoneBuilder poolId(String poolId) {
+            model.poolId = poolId;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getProjectId()
+         */
+        @Override
+        public ZoneBuilder projectId(String projectId) {
+            model.projectId = projectId;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getName()
+         */
+        @Override
+        public ZoneBuilder name(String name) {
+            model.name = name;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getEmail()
+         */
+        @Override
+        public ZoneBuilder email(String email) {
+            model.email = email;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getTTL()
+         */
+        @Override
+        public ZoneBuilder ttl(Integer ttl) {
+            model.ttl = ttl;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getSerial()
+         */
+        @Override
+        public ZoneBuilder serial(String serial) {
+            model.serial = serial;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getStatus()
+         */
+        @Override
+        public ZoneBuilder status(Status status) {
+            model.status = status;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getAction()
+         */
+        @Override
+        public ZoneBuilder action(Action action) {
+            model.action = action;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getDescription()()
+         */
+        @Override
+        public ZoneBuilder description(String description) {
+            model.description = description;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getMasters()
+         */
+        @Override
+        public ZoneBuilder masters(List<String> masters) {
+            model.masters = masters;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getType()
+         */
+        @Override
+        public ZoneBuilder type(ZoneType type) {
+            model.type = type;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getTransferedAt()
+         */
+        @Override
+        public ZoneBuilder transferredAt(String transferredAt) {
+            model.transferredAt = transferredAt;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getVersion()
+         */
+        @Override
+        public ZoneBuilder version(Integer version) {
+            model.version = version;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getCreatedAt()
+         */
+        @Override
+        public ZoneBuilder createdAt(String createdAt) {
+            model.createdAt = createdAt;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getUpdatedAt()
+         */
+        @Override
+        public ZoneBuilder updatedAt(String updatedAt) {
+            model.updatedAt = updatedAt;
+            return this;
+        }
+
+        /**
+         * @see DesignateZone#getLinks()
+         */
+        @Override
+        public ZoneBuilder links(Map<String, String> links) {
+            model.links = links;
+            return this;
+        }
+    }
+
+    public static class Zones extends ListResult<DesignateZone> {
+
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("zones")
+        protected List<DesignateZone> list;
+
+        @Override
+        public List<DesignateZone> value() {
+            return list;
+        }
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/BaseDNSServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/BaseDNSServices.java
@@ -1,0 +1,12 @@
+package org.openstack4j.openstack.dns.v2.internal;
+
+import org.openstack4j.api.types.ServiceType;
+import org.openstack4j.openstack.common.functions.EnforceVersionToURL;
+import org.openstack4j.openstack.internal.BaseOpenStackService;
+
+public class BaseDNSServices extends BaseOpenStackService {
+
+	protected BaseDNSServices() {
+		super(ServiceType.DNS, EnforceVersionToURL.instance("/v2"));
+	}
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/DNSServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/DNSServiceImpl.java
@@ -1,0 +1,29 @@
+package org.openstack4j.openstack.dns.v2.internal;
+
+import org.openstack4j.api.Apis;
+import org.openstack4j.api.dns.v2.DNSService;
+import org.openstack4j.api.dns.v2.RecordsetService;
+import org.openstack4j.api.dns.v2.ZoneService;
+import org.openstack4j.model.common.Extension;
+import org.openstack4j.openstack.common.ExtensionValue.ExtensionList;
+import org.openstack4j.openstack.internal.BaseOpenStackService;
+
+import java.util.List;
+
+
+/**
+ * DNS/Designate V2 service implementation
+ *
+ */
+public class DNSServiceImpl extends BaseDNSServices implements DNSService {
+
+    @Override
+    public ZoneService zones() {
+        return Apis.get(ZoneService.class);
+    }
+
+    @Override
+    public RecordsetService recordsets() {
+        return Apis.get(RecordsetService.class);
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/RecordsetServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/RecordsetServiceImpl.java
@@ -1,0 +1,64 @@
+package org.openstack4j.openstack.dns.v2.internal;
+
+import org.openstack4j.api.dns.v2.RecordsetService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.dns.v2.Recordset;
+import org.openstack4j.openstack.dns.v2.domain.DesignateRecordset;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.openstack4j.core.transport.ClientConstants.PATH_ZONES;
+import static org.openstack4j.core.transport.ClientConstants.PATH_RECORDSETS;
+
+public class RecordsetServiceImpl extends BaseDNSServices implements RecordsetService {
+
+    @Override
+    public Recordset get(String zoneId, String recordsetId) {
+        checkNotNull(zoneId);
+        checkNotNull(recordsetId);
+        return get(DesignateRecordset.class, PATH_ZONES, "/", zoneId, PATH_RECORDSETS, "/", recordsetId).execute();
+    }
+
+    @Override
+    public ActionResponse delete(String zoneId, String recordsetId) {
+        checkNotNull(zoneId);
+        checkNotNull(recordsetId);
+        return deleteWithResponse(PATH_ZONES, "/", zoneId, PATH_RECORDSETS, "/", recordsetId).execute();
+    }
+
+    @Override
+    public Recordset update(String zoneId, Recordset recordset) {
+        checkNotNull(zoneId);
+        checkNotNull(recordset);
+        return put(DesignateRecordset.class, PATH_ZONES, "/", zoneId, PATH_RECORDSETS, "/", recordset.getId()).entity(recordset).execute();
+    }
+
+    @Override
+    public Recordset create(String zoneId, Recordset recordset) {
+        checkNotNull(zoneId);
+        checkNotNull(recordset);
+        return post(DesignateRecordset.class, PATH_ZONES, "/", zoneId, PATH_RECORDSETS).entity(recordset).execute();
+    }
+
+    @Override
+    public Recordset create(String zoneId, String name, String type, List<String> records) {
+        checkNotNull(zoneId);
+        checkNotNull(name);
+        checkNotNull(type);
+        checkNotNull(records);
+        return create(zoneId, DesignateRecordset.builder().name(name).type(type).records(records).build());
+    }
+
+    @Override
+    public List<? extends Recordset> list(String zoneId) {
+        checkNotNull(zoneId);
+        return get(DesignateRecordset.Recordsets.class, PATH_ZONES, "/", zoneId, PATH_RECORDSETS).execute().getList();
+    }
+
+    @Override
+    public List<? extends Recordset> list() {
+        return get(DesignateRecordset.Recordsets.class, uri(PATH_RECORDSETS)).execute().getList();
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/ZoneServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/dns/v2/internal/ZoneServiceImpl.java
@@ -1,0 +1,61 @@
+package org.openstack4j.openstack.dns.v2.internal;
+
+import org.openstack4j.api.dns.v2.ZoneService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.dns.v2.Nameserver;
+import org.openstack4j.model.dns.v2.Zone;
+import org.openstack4j.openstack.dns.v2.domain.DesignateNameserver;
+import org.openstack4j.openstack.dns.v2.domain.DesignateZone;
+import org.openstack4j.openstack.internal.BaseOpenStackService;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.openstack4j.core.transport.ClientConstants.PATH_ZONES;
+import static org.openstack4j.core.transport.ClientConstants.PATH_NAMESERVERS;
+
+public class ZoneServiceImpl extends BaseDNSServices implements ZoneService {
+
+    @Override
+    public Zone get(String zoneId) {
+        checkNotNull(zoneId);
+        return get(DesignateZone.class, PATH_ZONES, "/", zoneId).execute();
+    }
+
+    @Override
+    public ActionResponse delete(String zoneId) {
+        checkNotNull(zoneId);
+        return deleteWithResponse(PATH_ZONES, "/", zoneId).execute();
+    }
+
+    @Override
+    public List<? extends Nameserver> listNameservers(String zoneId) {
+        checkNotNull(zoneId);
+        return get(DesignateNameserver.Nameservers.class, PATH_ZONES, "/",zoneId, PATH_NAMESERVERS).execute().getList();
+    }
+
+    @Override
+    public Zone update(Zone zone) {
+        checkNotNull(zone);
+        return patch(DesignateZone.class, PATH_ZONES, "/", zone.getId()).entity(zone).execute();
+    }
+
+    @Override
+    public Zone create(Zone zone) {
+        checkNotNull(zone);
+        return post(DesignateZone.class, uri(PATH_ZONES)).entity(zone).execute();
+    }
+
+    @Override
+    public Zone create(String name, String email) {
+        checkNotNull(name);
+        checkNotNull(email);
+        return create(DesignateZone.builder().name(name).email(email).build());
+    }
+
+    @Override
+    public List<? extends Zone> list() {
+        return get(DesignateZone.Zones.class, uri(PATH_ZONES)).execute().getList();
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSClientSession.java
@@ -12,6 +12,7 @@ import org.openstack4j.api.artifact.ArtifactService;
 import org.openstack4j.api.barbican.BarbicanService;
 import org.openstack4j.api.client.CloudProvider;
 import org.openstack4j.api.compute.ComputeService;
+import org.openstack4j.api.dns.v2.DNSService;
 import org.openstack4j.api.gbp.GbpService;
 import org.openstack4j.api.heat.HeatService;
 import org.openstack4j.api.identity.EndpointURLResolver;
@@ -217,6 +218,11 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
     /**
      * {@inheritDoc}
      */
+    public DNSService dns() {return Apis.getDNSService(); }
+
+    /**
+     * {@inheritDoc}
+     */
     @SuppressWarnings("unchecked")
     public T perspective(Facing perspective) {
         this.perspective = perspective;
@@ -290,6 +296,9 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
         return getSupportedServices().contains(ServiceType.TELEMETRY);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public boolean supportsTelemetry_aodh() {
         return getSupportedServices().contains(ServiceType.TELEMETRY_AODH);
     }
@@ -302,10 +311,14 @@ public abstract class OSClientSession<R, T extends OSClient<T>> implements Endpo
     }
 
     /**
-     *
-     * @return
+     * {@inheritDoc}
      */
     public boolean supportsTrove() { return getSupportedServices().contains(ServiceType.DATABASE); }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean supportsDNS() { return getSupportedServices().contains(ServiceType.DNS); }
 
     public Set<ServiceType> getSupportedServices() {
         return null;

--- a/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
+++ b/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
@@ -28,6 +28,8 @@ import org.openstack4j.api.compute.ext.InterfaceService;
 import org.openstack4j.api.compute.ext.MigrationService;
 import org.openstack4j.api.compute.ext.ServicesService;
 import org.openstack4j.api.compute.ext.ZoneService;
+import org.openstack4j.api.dns.v2.DNSService;
+import org.openstack4j.api.dns.v2.RecordsetService;
 import org.openstack4j.api.exceptions.ApiNotFoundException;
 import org.openstack4j.api.gbp.ExternalPolicyService;
 import org.openstack4j.api.gbp.ExternalSegmentService;
@@ -185,6 +187,8 @@ import org.openstack4j.openstack.compute.internal.ext.InstanceActionsServiceImpl
 import org.openstack4j.openstack.compute.internal.ext.InterfaceServiceImpl;
 import org.openstack4j.openstack.compute.internal.ext.MigrationServiceImpl;
 import org.openstack4j.openstack.compute.internal.ext.ZoneServiceImpl;
+import org.openstack4j.openstack.dns.v2.internal.DNSServiceImpl;
+import org.openstack4j.openstack.dns.v2.internal.RecordsetServiceImpl;
 import org.openstack4j.openstack.gbp.internal.ExternalPolicyServiceImpl;
 import org.openstack4j.openstack.gbp.internal.ExternalSegmentServiceImpl;
 import org.openstack4j.openstack.gbp.internal.GbpServiceImpl;
@@ -498,6 +502,9 @@ public class DefaultAPIProvider implements APIProvider {
         bind(ServicesService.class, ServicesServiceImpl.class);
         bind(BlockStorageServiceService.class, BlockStorageServiceServiceImpl.class);
         bind(MagnumService.class, MagnumServiceImpl.class);
+        bind(DNSService.class, DNSServiceImpl.class);
+        bind(org.openstack4j.api.dns.v2.ZoneService.class, org.openstack4j.openstack.dns.v2.internal.ZoneServiceImpl.class);
+        bind(RecordsetService.class, RecordsetServiceImpl.class);
     }
 
     /**


### PR DESCRIPTION
This PR introduces the DNS/Designate V2 API. Currently only Zones and Recordsets operations are covered.

Note: The content of DesignateRecordsetServiceSpec.groovy and DesignateZoneServiceSpec.groovy is commented out right now, as I cannot convince betamax to actually write to the tapes. Grr! Added a couple of unit tests instead. Will take care of that next week.

/cc @gondor @vinodborole 