### PR TITLE
Add additional properties of the availability zone hint for the network.

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
@@ -36,6 +36,7 @@ public class NetworkTests extends AbstractTest {
     private static final String JSON_NETWORK = "/network/network.json";
     private static final String JSON_AGENTS = "/network/agents.json";
     private static final String JSON_NETWORK_EXTERNAL = "/network/network-external.json";
+    private static final String JSON_NETWORK_ZONE = "/network/network_zone.json";
     private static final String NETWORK_NAME = "net1";
     private static final String NETWORK_ID = "4e8e5957-649f-477b-9e5b-f1f75b21c03c";
 
@@ -59,6 +60,17 @@ public class NetworkTests extends AbstractTest {
         assertEquals(n.getStatus(), State.ACTIVE);
         assertEquals(n.isRouterExternal(), true);
     }
+    
+    @Test
+    public void createNetworkWithZone() throws Exception {
+        respondWith(JSON_NETWORK_ZONE);
+        Network n = osv3().networking().network()
+                .create(Builders.network().name(NETWORK_NAME).isRouterExternal(true).adminStateUp(true).addAvailabilityZoneHints("nova").build());
+        server.takeRequest();	 
+        assertEquals(n.getName(), NETWORK_NAME);
+        assertEquals(n.getStatus(), State.ACTIVE);
+        assertEquals(n.getAvailabilityZoneHints().get(0), "nova");
+    }    
 
     @Test
     public void agentList() throws Exception {

--- a/core-test/src/main/resources/network/network_zone.json
+++ b/core-test/src/main/resources/network/network_zone.json
@@ -1,0 +1,22 @@
+{
+    "network": {
+        "admin_state_up": true,
+        "availability_zone_hints": ["nova"],
+        "availability_zones": [],
+        "created_at": "2016-03-08T20:19:41",
+        "id": "4e8e5957-649f-477b-9e5b-f1f75b21c03c",
+        "mtu": 0,
+        "name": "net1",
+        "port_security_enabled": true,
+        "project_id": "9bacb3c5d39d41a79512987f338cf177",
+        "qos_policy_id": "6a8454ade84346f59e8d40665f878b2e",
+        "router:external": false,
+        "shared": false,
+        "status": "ACTIVE",
+        "subnets": [],
+        "tenant_id": "9bacb3c5d39d41a79512987f338cf177",
+        "updated_at": "2016-03-08T20:19:41",
+        "vlan_transparent": false,
+        "description": ""
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/network/Network.java
+++ b/core/src/main/java/org/openstack4j/model/network/Network.java
@@ -63,4 +63,15 @@ public interface Network extends Resource, Buildable<NetworkBuilder> {
 	 */
 	Integer getMTU();
 	
+	/**
+	 * @return the list of the availability zone candidate for the network.
+	 */
+	List<String> getAvailabilityZoneHints();
+	
+	/**
+	 * @return the list of the availability zone for the network.
+	 */
+	List<String> getAvailabilityZones();
+	
+	
 }

--- a/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/NetworkBuilder.java
@@ -50,4 +50,9 @@ public interface NetworkBuilder extends Builder<NetworkBuilder, Network> {
 	 * @see Network#isRouterExternal()
 	 */
 	NetworkBuilder isRouterExternal(boolean routerExternal);
+	
+	/**
+	 * @see Network#getAvailabilityZoneHints()
+	 */
+	NetworkBuilder addAvailabilityZoneHints(String availabilityZone);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetwork.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronNetwork.java
@@ -9,12 +9,14 @@ import org.openstack4j.model.network.NetworkType;
 import org.openstack4j.model.network.State;
 import org.openstack4j.model.network.Subnet;
 import org.openstack4j.model.network.builder.NetworkBuilder;
+import org.openstack4j.model.network.builder.PortBuilder;
 import org.openstack4j.openstack.common.ListResult;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Sets;
 
 /**
  * An OpenStack (Neutron) network
@@ -45,6 +47,12 @@ public class NeutronNetwork implements Network {
     private Boolean shared;
     @JsonProperty("provider:segmentation_id")
     private String providerSegID;
+    @JsonProperty("availability_zone_hints")
+    private List<String> availabilityZoneHints;
+    @JsonProperty("availability_zones")
+    private List<String> availabilityZones;    
+    
+    
     /**
      * The maximum transmission unit (MTU) value to address fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
      */
@@ -199,6 +207,23 @@ public class NeutronNetwork implements Network {
 	public Integer getMTU() {
 		return mtu;
 	}
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getAvailabilityZoneHints() {
+        return availabilityZoneHints;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getAvailabilityZones() {
+        return availabilityZones;
+    }
+    
 
     /**
      * {@inheritDoc}
@@ -209,7 +234,7 @@ public class NeutronNetwork implements Network {
                 .add("name", name).add("status", status).add("subnets", subnets).add("provider:physical_network", providerPhyNet)
                 .add("adminStateUp", adminStateUp).add("tenantId", tenantId).add("provider:network_type", networkType).add("router:external", routerExternal)
                 .add("id", id).add("shared", shared).add("provider:segmentation_id", providerSegID)
-                .add("mtu", mtu)
+                .add("mtu", mtu).add("availabilityZoneHints", availabilityZoneHints).add("availabilityZones", availabilityZones)
                 .toString();
     }
 
@@ -220,7 +245,7 @@ public class NeutronNetwork implements Network {
     public int hashCode() {
         return java.util.Objects.hash(name, status, subnets,
                 providerPhyNet, adminStateUp, tenantId, networkType,
-                routerExternal, id, shared, providerSegID);
+                routerExternal, id, shared, providerSegID, availabilityZoneHints, availabilityZones);
     }
 
     /**
@@ -244,7 +269,9 @@ public class NeutronNetwork implements Network {
                     java.util.Objects.equals(routerExternal, that.routerExternal) &&
                     java.util.Objects.equals(id, that.id) &&
                     java.util.Objects.equals(shared, that.shared) &&
-                    java.util.Objects.equals(providerSegID, that.providerSegID)) {
+                    java.util.Objects.equals(providerSegID, that.providerSegID) &&
+                    java.util.Objects.equals(availabilityZoneHints, that.availabilityZoneHints) &&
+                    java.util.Objects.equals(availabilityZones, that.availabilityZones)) {
                 return true;
             }
         }
@@ -333,5 +360,14 @@ public class NeutronNetwork implements Network {
             m = (NeutronNetwork) in;
             return this;
         }
+        
+        @Override
+		public NetworkBuilder addAvailabilityZoneHints(String availabilityZone) {
+        	if(m.availabilityZoneHints==null){
+				m.availabilityZoneHints = new ArrayList<>();
+			}
+			m.availabilityZoneHints.add(availabilityZone);
+			return this;			        	
+		}
     }
 }


### PR DESCRIPTION
Hi, I Added two perperties for availability zone for the network.
-  availability_zone_hints : The availability zone candidate for the network. (create and read)
-  availability_zones : 	The availability zone for the network. (read only)
* these properties is for Mitaka or above.
