### PR TITLE
Mistral: adding workflow executions endpoint

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/workflow/ActionDefinitionTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/workflow/ActionDefinitionTest.java
@@ -123,7 +123,6 @@ public class ActionDefinitionTest extends WorkflowBaseTest {
 
         ActionResponse resp = service.delete("concat");
 
-        // TODO(rakhmerov): Change to 204 once ActionResponse can return other 2xx codes.
-        assertEquals(resp.getCode(), 200);
+        assertEquals(resp.getCode(), 204);
     }
 }

--- a/core-test/src/main/java/org/openstack4j/api/workflow/WorkbookDefinitionTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/workflow/WorkbookDefinitionTest.java
@@ -112,7 +112,6 @@ public class WorkbookDefinitionTest extends WorkflowBaseTest {
 
         ActionResponse resp = service.delete("my_wb");
 
-        // TODO(rakhmerov): Change to 204 once ActionResponse can return other 2xx codes.
-        assertEquals(resp.getCode(), 200);
+        assertEquals(resp.getCode(), 204);
     }
 }

--- a/core-test/src/main/java/org/openstack4j/api/workflow/WorkflowDefinitionTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/workflow/WorkflowDefinitionTest.java
@@ -127,7 +127,6 @@ public class WorkflowDefinitionTest extends WorkflowBaseTest {
 
         ActionResponse resp = service.delete("with_items_40");
 
-        // TODO(rakhmerov): Change to 204 once ActionResponse can return other 2xx codes.
-        assertEquals(resp.getCode(), 200);
+        assertEquals(resp.getCode(), 204);
     }
 }

--- a/core-test/src/main/java/org/openstack4j/api/workflow/WorkflowExecutionTest.java
+++ b/core-test/src/main/java/org/openstack4j/api/workflow/WorkflowExecutionTest.java
@@ -1,0 +1,130 @@
+package org.openstack4j.api.workflow;
+
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.workflow.State;
+import org.openstack4j.model.workflow.WorkflowExecution;
+import org.openstack4j.openstack.workflow.domain.MistralWorkflowExecution.MistralWorkflowExecutionBuilder;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/**
+ * Test cases for {@link WorkflowExecutionService}.
+ * 
+ * @author Renat Akhmerov
+ */
+@Test(suiteName="WorkflowExecutions")
+public class WorkflowExecutionTest extends WorkflowBaseTest {
+
+    private static final String JSON_WF_EXEC = "/workflow/wf_exec.json";
+    private static final String JSON_WF_EXECS = "/workflow/wf_execs.json";
+    private static final String JSON_WF_EXEC_CREATE = "/workflow/wf_exec_create.json";
+
+    private WorkflowExecutionService service;
+
+    @BeforeTest
+    public void setUp() {
+        this.service = osv3().workflow().workflowExecutions();
+    }
+
+    @Test
+    public void listWorkflowExecutions() throws Exception {
+        respondWith(JSON_WF_EXECS);
+        
+        List<? extends WorkflowExecution> wfExecs = service.list();
+
+        assertEquals(wfExecs.size(), 2);
+
+        // Check first workflow execution.
+        WorkflowExecution wfExec = wfExecs.get(0);
+
+        assertNotNull(wfExec);
+        assertIsUUID(wfExec.getId());
+        assertEquals(wfExec.getWorkflowName(), "parallel_join_2");
+        assertNull(wfExec.getTags());
+        assertNotNull(wfExec.getCreatedAt());
+        assertNotNull(wfExec.getUpdatedAt());
+        assertNotNull(wfExec.getInput());
+        assertEquals(wfExec.getInput().size(), 0);
+        assertNotNull(wfExec.getParameters());
+        assertEquals(wfExec.getParameters().size(), 0);
+        assertEquals(wfExec.getState(), State.SUCCESS);
+        assertNull(wfExec.getStateInfo());
+
+        // Check second workflow execution.
+        wfExec = wfExecs.get(1);
+
+        assertNotNull(wfExec);
+        assertIsUUID(wfExec.getId());
+        assertEquals(wfExec.getWorkflowName(), "parallel_join_2");
+        assertNotNull(wfExec.getTags());
+        assertEquals(wfExec.getTags().size(), 2);
+        assertEquals(wfExec.getTags().get(0), "test");
+        assertEquals(wfExec.getTags().get(1), "private");
+        assertNotNull(wfExec.getCreatedAt());
+        assertNotNull(wfExec.getUpdatedAt());
+        assertNotNull(wfExec.getInput());
+        assertEquals(wfExec.getInput().size(), 0);
+        assertEquals(wfExec.getState(), State.ERROR);
+        assertEquals(wfExec.getStateInfo(), "Failed for reason X");
+    }
+
+    @Test
+    public void getWorkflowExecution() throws Exception {
+        respondWith(JSON_WF_EXEC);
+
+        WorkflowExecution wfExec = service.get("79d187f4-b8e5-4288-b2cd-ed27ee31e4b0");
+
+        assertNotNull(wfExec);
+        assertIsUUID(wfExec.getId());
+        assertEquals(wfExec.getWorkflowName(), "parallel_join_2");
+        assertNull(wfExec.getTags());
+        assertNotNull(wfExec.getCreatedAt());
+        assertNotNull(wfExec.getUpdatedAt());
+        assertNotNull(wfExec.getInput());
+        assertEquals(wfExec.getInput().size(), 0);
+        assertNotNull(wfExec.getParameters());
+        assertEquals(wfExec.getParameters().size(), 0);
+        assertEquals(wfExec.getState(), State.SUCCESS);
+        assertNull(wfExec.getStateInfo());
+    }
+
+    @Test
+    public void createWorkflowExecution() throws Exception {
+        respondWith(JSON_WF_EXEC_CREATE);
+
+        WorkflowExecution wfExec = new MistralWorkflowExecutionBuilder().
+                workflowName("parallel_join_2").
+                parameters(Collections.<String, Object>singletonMap("env", "my_env")).
+                build();
+
+        wfExec = service.create(wfExec);
+
+        assertNotNull(wfExec);
+        assertIsUUID(wfExec.getId());
+        assertEquals(wfExec.getWorkflowName(), "parallel_join_2");
+        assertNull(wfExec.getTags());
+        assertNotNull(wfExec.getCreatedAt());
+        assertNull(wfExec.getUpdatedAt());
+        assertNotNull(wfExec.getInput());
+        assertEquals(wfExec.getInput().size(), 0);
+        assertNotNull(wfExec.getParameters());
+        assertEquals(wfExec.getParameters().size(), 1);
+        assertEquals(wfExec.getParameters().get("env"), "my_env");
+        assertEquals(wfExec.getState(), State.RUNNING);
+        assertNull(wfExec.getStateInfo());
+    }
+
+    @Test
+    public void deleteWorkflowExecution() throws Exception {
+        respondWith(204); // No content.
+
+        ActionResponse resp = service.delete("parallel_join_2");
+
+        assertEquals(resp.getCode(), 204);
+    }
+}

--- a/core-test/src/main/resources/workflow/new_wf_exec.json
+++ b/core-test/src/main/resources/workflow/new_wf_exec.json
@@ -1,0 +1,5 @@
+{
+  "workflow_name": "parallel_join_2",
+  "params": "{}",
+  "input": "{}"
+}

--- a/core-test/src/main/resources/workflow/wf_exec.json
+++ b/core-test/src/main/resources/workflow/wf_exec.json
@@ -1,0 +1,13 @@
+{
+  "id": "79d187f4-b8e5-4288-b2cd-ed27ee31e4b0",
+  "description": "",
+  "created_at": "2016-08-17 10:34:00",
+  "updated_at": "2016-08-17 10:34:02",
+  "workflow_id": "0169affc-e6a1-4013-a59e-c89dfd5523f2",
+  "workflow_name": "parallel_join_2",
+  "params": {},
+  "input": {},
+  "state": "SUCCESS",
+  "state_info": null,
+  "task_execution_id": null
+}

--- a/core-test/src/main/resources/workflow/wf_exec_create.json
+++ b/core-test/src/main/resources/workflow/wf_exec_create.json
@@ -1,0 +1,12 @@
+{
+  "id": "79d187f4-b8e5-4288-b2cd-ed27ee31e4b0",
+  "description": "",
+  "created_at": "2016-08-17 10:34:00",
+  "workflow_id": "0169affc-e6a1-4013-a59e-c89dfd5523f2",
+  "workflow_name": "parallel_join_2",
+  "params": {"env": "my_env"},
+  "input": {},
+  "state": "RUNNING",
+  "state_info": null,
+  "task_execution_id": null
+}

--- a/core-test/src/main/resources/workflow/wf_execs.json
+++ b/core-test/src/main/resources/workflow/wf_execs.json
@@ -1,0 +1,31 @@
+{
+  "executions": [
+    {
+      "id": "79d187f4-b8e5-4288-b2cd-ed27ee31e4b0",
+      "description": "",
+      "created_at": "2016-08-17 10:34:00",
+      "updated_at": "2016-08-17 10:34:02",
+      "workflow_id": "0169affc-e6a1-4013-a59e-c89dfd5523f2",
+      "workflow_name": "parallel_join_2",
+      "params": {},
+      "input": {},
+      "state": "SUCCESS",
+      "state_info": null,
+      "task_execution_id": null
+    },
+    {
+      "id": "7af6a8e3-96f1-4928-8363-e244032b5419",
+      "description": "",
+      "created_at": "2016-08-17 10:35:05",
+      "updated_at": "2016-08-17 10:35:05",
+      "tags": ["test", "private"],
+      "workflow_id": "0169affc-e6a1-4013-a59e-c89dfd5523f2",
+      "workflow_name": "parallel_join_2",
+      "params": {},
+      "input": {},
+      "state": "ERROR",
+      "state_info": "Failed for reason X",
+      "task_execution_id": null
+    }
+  ]
+}

--- a/core/src/main/java/org/openstack4j/api/workflow/WorkflowExecutionService.java
+++ b/core/src/main/java/org/openstack4j/api/workflow/WorkflowExecutionService.java
@@ -1,7 +1,6 @@
 package org.openstack4j.api.workflow;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.workflow.WorkflowExecution;
 
@@ -23,10 +22,10 @@ public interface WorkflowExecutionService extends RestService {
     /**
      * Create a new workflow execution.
      *
-     * @param workflowExecution Workflow execution to create.
+     * @param wfExec Workflow execution to create.
      * @return Created workflow execution.
      */
-    WorkflowExecution create(WorkflowExecution workflowExecution);
+    WorkflowExecution create(WorkflowExecution wfExec);
 
     /**
      * Get workflow execution by its ID.
@@ -40,7 +39,7 @@ public interface WorkflowExecutionService extends RestService {
      * Delete workflow execution by its ID.
      *
      * @param id Workflow execution ID.
-     * @return HTTP response from the server.
+     * @return Action response from the server.
      */
-    HttpResponse delete(String id);
+    ActionResponse delete(String id);
 }

--- a/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
+++ b/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
@@ -60,7 +60,7 @@ public class HttpEntityHandler {
             }
 
             if (returnType == ActionResponse.class) {
-                return (T) ActionResponse.actionSuccess();
+                return (T) ActionResponse.actionSuccess(response.getStatus());
             }
 
             return response.readEntity(returnType);

--- a/core/src/main/java/org/openstack4j/model/common/ActionResponse.java
+++ b/core/src/main/java/org/openstack4j/model/common/ActionResponse.java
@@ -5,8 +5,10 @@ import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 
 /**
- * A response that is returned when an Action is performed against the server.  If {@link #isSuccess()} is true then the fault will always be null. The fault
- * will indicate why the action has failed.  Any other transport/communication errors will be thrown as with any other API calls.
+ * A response that is returned when an Action is performed against the server.
+ * If {@link #isSuccess()} is true then the fault will always be null.
+ * The fault will indicate why the action has failed.  Any other transport/communication
+ * errors will be thrown as with any other API calls.
  *
  * @author Jeremy Unruh
  */
@@ -14,18 +16,23 @@ public class ActionResponse implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	String message;
-	int code;
+	private String message;
+	private int code;
 
 	private ActionResponse(int code) {
 	    this.code = code;
 	}
+
 	private ActionResponse(String message, int code) {
 	    this(code);
 		this.message = message;
 	}
 
-	public static ActionResponse actionSuccess() {
+    public static ActionResponse actionSuccess(int code) {
+        return new ActionResponse(code);
+    }
+
+    public static ActionResponse actionSuccess() {
 		return new ActionResponse(200);
 	}
 
@@ -55,9 +62,14 @@ public class ActionResponse implements Serializable {
 	public String getFault() {
 		return message;
 	}
+
 	@Override
 	public String toString() {
-		return MoreObjects.toStringHelper(this).omitNullValues().add("success", message == null).add("fault", message).add("code", code).toString();
+		return MoreObjects.toStringHelper(this).
+                omitNullValues().
+                add("success", message == null).
+                add("fault", message).
+                add("code", code).
+                toString();
 	}
-
 }

--- a/core/src/main/java/org/openstack4j/model/workflow/ActionExecution.java
+++ b/core/src/main/java/org/openstack4j/model/workflow/ActionExecution.java
@@ -15,7 +15,7 @@ import java.util.Map;
  *
  * @author Renat Akhmerov
  */
-public interface ActionExecution extends Execution, Buildable<ActionExecutionBuilder> {
+public interface ActionExecution extends Execution {
     /**
      * @return The name of the corresponding task.
      */

--- a/core/src/main/java/org/openstack4j/model/workflow/Execution.java
+++ b/core/src/main/java/org/openstack4j/model/workflow/Execution.java
@@ -3,7 +3,9 @@
  */
 package org.openstack4j.model.workflow;
 
+import org.openstack4j.common.Buildable;
 import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.workflow.builder.ExecutionBuilder;
 
 import java.util.Date;
 import java.util.List;
@@ -14,7 +16,7 @@ import java.util.List;
  * 
  * @author Renat Akhmerov
  */
-public interface Execution extends ModelEntity {
+public interface Execution extends ModelEntity, Buildable<ExecutionBuilder> {
 	/**
 	 * @return The id of this execution.
 	 */
@@ -46,12 +48,12 @@ public interface Execution extends ModelEntity {
     List<String> getTags();
 
     /**
-	 * @return The time that this entity was createdAt at.
+	 * @return The time that this entity was created at.
 	 */
-	Date getCreated();
+	Date getCreatedAt();
 
 	/**
-	 * @return The time that this entity was last updatedAt at.
+	 * @return The time that this entity was last updated at.
 	 */
-	Date getUpdated();
+	Date getUpdatedAt();
 }

--- a/core/src/main/java/org/openstack4j/model/workflow/TaskExecution.java
+++ b/core/src/main/java/org/openstack4j/model/workflow/TaskExecution.java
@@ -14,7 +14,7 @@ import java.util.Map;
  *
  * @author Renat Akhmerov
  */
-public interface TaskExecution extends Execution, Buildable<TaskExecutionBuilder> {
+public interface TaskExecution extends Execution {
     /**
      * @return The task name.
      */

--- a/core/src/main/java/org/openstack4j/model/workflow/WorkflowExecution.java
+++ b/core/src/main/java/org/openstack4j/model/workflow/WorkflowExecution.java
@@ -15,13 +15,13 @@ import java.util.Map;
  *
  * @author Renat Akhmerov
  */
-public interface WorkflowExecution extends Execution, Buildable<WorkflowExecutionBuilder> {
+public interface WorkflowExecution extends Execution {
     /**
      * @return The meta parameters of workflow execution specific to workflow type.
      *      Example: a reverse workflow requires the parameter 'task_name' which
      *      specifies the target task in the workflow graph.
      */
-    Map<String, ?> getParameters();
+    Map<String, Object> getParameters();
 
     /**
      * @return The id of the parent task execution.
@@ -32,10 +32,10 @@ public interface WorkflowExecution extends Execution, Buildable<WorkflowExecutio
     /**
      * @return The input parameters of this workflow execution.
      */
-    Map<String, ?> getInput();
+    Map<String, Object> getInput();
 
     /**
      * @return The output of this workflow execution.
      */
-    Map<String, ?> getOutput();
+    Map<String, Object> getOutput();
 }

--- a/core/src/main/java/org/openstack4j/model/workflow/builder/ExecutionBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/workflow/builder/ExecutionBuilder.java
@@ -1,0 +1,46 @@
+package org.openstack4j.model.workflow.builder;
+
+import org.openstack4j.common.Buildable.Builder;
+import org.openstack4j.model.workflow.Definition;
+import org.openstack4j.model.workflow.Execution;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Builder for {@link Execution} model class.
+ * 
+ * @author Renat Akhmerov
+ */
+public interface ExecutionBuilder<T extends ExecutionBuilder<T, M>, M extends Execution>
+        extends Builder<T, M> {
+	/**
+	 * @see Execution#getId()
+	 */
+	T id(String id);
+
+	/**
+	 * @see Execution#getDescription()
+	 */
+	T description(String id);
+
+	/**
+	 * @see Execution#getWorkflowName()
+	 */
+	T workflowName(String name);
+
+	/**
+	 * @see Execution#getCreatedAt()
+	 */
+	T createdAt(Date createdAt);
+
+	/**
+	 * @see Execution#getUpdatedAt()
+	 */
+	T updatedAt(Date updatedAt);
+
+	/**
+	 * @see Execution#getTags()
+	 */
+	T tags(List<String> tags);
+}

--- a/core/src/main/java/org/openstack4j/model/workflow/builder/WorkflowBuilders.java
+++ b/core/src/main/java/org/openstack4j/model/workflow/builder/WorkflowBuilders.java
@@ -1,7 +1,5 @@
 package org.openstack4j.model.workflow.builder;
 
-import org.openstack4j.model.sahara.builder.*;
-
 /**
  * The Workflow service builders.
  */
@@ -12,6 +10,26 @@ public interface WorkflowBuilders {
      *
      * @return the workflow definition builder.
      */
-    public WorkflowDefinitionBuilder workflowDefinition();
+    WorkflowDefinitionBuilder workflowDefinition();
 
+    /**
+     * The builder to create a workbook definition.
+     *
+     * @return the workbook definition builder.
+     */
+    WorkbookDefinitionBuilder workbookDefinition();
+
+    /**
+     * The builder to create an action definition.
+     *
+     * @return the action definition builder.
+     */
+    ActionDefinitionBuilder actionDefinition();
+
+    /**
+     * The builder to create a workflow execution.
+     *
+     * @return the workflow execution builder.
+     */
+    WorkflowExecutionBuilder workflowExecution();
 }

--- a/core/src/main/java/org/openstack4j/model/workflow/builder/WorkflowExecutionBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/workflow/builder/WorkflowExecutionBuilder.java
@@ -1,19 +1,34 @@
 package org.openstack4j.model.workflow.builder;
 
-import org.openstack4j.common.Buildable.Builder;
 import org.openstack4j.model.workflow.WorkflowExecution;
+
+import java.util.Map;
 
 /**
  * Builder for a {@link WorkflowExecution} model class
  * 
  * @author Renat Akhmerov
  */
-public interface WorkflowExecutionBuilder extends Builder<WorkflowExecutionBuilder, WorkflowExecution> {
+public interface WorkflowExecutionBuilder<T extends WorkflowExecutionBuilder<T, M>, M extends WorkflowExecution>
+		extends ExecutionBuilder<T, M> {
 
-	/**
-	 * @see WorkflowExecution#getId()
+    /**
+     * @see WorkflowExecution#getParameters()
+     */
+    T parameters(Map<String, Object> params);
+
+    /**
+	 * @see WorkflowExecution#getInput()
 	 */
-	WorkflowExecutionBuilder id(String id);
+	T input(Map<String, Object> input);
 
-	// TODO(rakhmerov): add all methods
+    /**
+     * @see WorkflowExecution#getOutput()
+     */
+    T output(Map<String, Object> output);
+
+    /**
+     * @see WorkflowExecution#getTaskExecutionId()
+     */
+    T taskExecutionId(String taskExecutionId);
 }

--- a/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
+++ b/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
@@ -162,10 +162,7 @@ import org.openstack4j.api.trove.DatastoreService;
 import org.openstack4j.api.trove.InstanceFlavorService;
 import org.openstack4j.api.trove.InstanceService;
 import org.openstack4j.api.trove.TroveService;
-import org.openstack4j.api.workflow.ActionDefinitionService;
-import org.openstack4j.api.workflow.WorkbookDefinitionService;
-import org.openstack4j.api.workflow.WorkflowDefinitionService;
-import org.openstack4j.api.workflow.WorkflowService;
+import org.openstack4j.api.workflow.*;
 import org.openstack4j.openstack.artifact.internal.ArtifactServiceImpl;
 import org.openstack4j.openstack.artifact.internal.ToscaTemplatesArtifactServiceImpl;
 import org.openstack4j.openstack.barbican.internal.BarbicanServiceImpl;
@@ -325,10 +322,7 @@ import org.openstack4j.openstack.trove.internal.DBUserServiceImpl;
 import org.openstack4j.openstack.trove.internal.TroveServiceImpl;
 
 import com.google.common.collect.Maps;
-import org.openstack4j.openstack.workflow.internal.ActionDefinitionServiceImpl;
-import org.openstack4j.openstack.workflow.internal.WorkbookDefinitionServiceImpl;
-import org.openstack4j.openstack.workflow.internal.WorkflowDefinitionServiceImpl;
-import org.openstack4j.openstack.workflow.internal.WorkflowServiceImpl;
+import org.openstack4j.openstack.workflow.internal.*;
 
 /**
  * Simple API Provider which keeps internally Maps interface implementations as singletons
@@ -519,6 +513,7 @@ public class DefaultAPIProvider implements APIProvider {
         bind(WorkflowDefinitionService.class, WorkflowDefinitionServiceImpl.class);
         bind(WorkbookDefinitionService.class, WorkbookDefinitionServiceImpl.class);
         bind(ActionDefinitionService.class, ActionDefinitionServiceImpl.class);
+        bind(WorkflowExecutionService.class, WorkflowExecutionServiceImpl.class);
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/workflow/builder/MistralBuilders.java
+++ b/core/src/main/java/org/openstack4j/openstack/workflow/builder/MistralBuilders.java
@@ -1,16 +1,33 @@
 package org.openstack4j.openstack.workflow.builder;
 
-import org.openstack4j.model.workflow.builder.WorkflowBuilders;
-import org.openstack4j.model.workflow.builder.WorkflowDefinitionBuilder;
+import org.openstack4j.model.workflow.builder.*;
+import org.openstack4j.openstack.workflow.domain.MistralActionDefinition;
+import org.openstack4j.openstack.workflow.domain.MistralWorkbookDefinition;
 import org.openstack4j.openstack.workflow.domain.MistralWorkflowDefinition;
+import org.openstack4j.openstack.workflow.domain.MistralWorkflowExecution;
 
 /**
- * The Mistral v2 Builders
+ * The Mistral v2 Builders.
  */
 public class MistralBuilders implements WorkflowBuilders {
 
     @Override
     public WorkflowDefinitionBuilder workflowDefinition() {
         return MistralWorkflowDefinition.builder();
+    }
+
+    @Override
+    public WorkbookDefinitionBuilder workbookDefinition() {
+        return MistralWorkbookDefinition.builder();
+    }
+
+    @Override
+    public ActionDefinitionBuilder actionDefinition() {
+        return MistralActionDefinition.builder();
+    }
+
+    @Override
+    public WorkflowExecutionBuilder workflowExecution() {
+        return MistralWorkflowExecution.builder();
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/workflow/domain/BaseExecution.java
+++ b/core/src/main/java/org/openstack4j/openstack/workflow/domain/BaseExecution.java
@@ -2,21 +2,23 @@ package org.openstack4j.openstack.workflow.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.openstack4j.model.workflow.Definition;
-import org.openstack4j.model.workflow.Scope;
-import org.openstack4j.model.workflow.builder.DefinitionBuilder;
+import org.openstack4j.model.workflow.Execution;
+import org.openstack4j.model.workflow.State;
+import org.openstack4j.model.workflow.builder.ExecutionBuilder;
 
 import java.util.Date;
 import java.util.List;
 
 
 /**
- * Base class for all definition models.
+ * Base class for all execution models.
  *
  * @author Renat Akhmerov
  */
-public abstract class BaseDefinition implements Definition {
+public abstract class BaseExecution implements Execution {
     String id;
+
+    String description;
 
     @JsonProperty("created_at")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -28,16 +30,13 @@ public abstract class BaseDefinition implements Definition {
 
     List<String> tags;
 
-    String name;
+    @JsonProperty("workflow_name")
+    String wfName;
 
-    String definition;
+    State state;
 
-    @JsonProperty("project_id")
-    String projectId;
-
-    Scope scope;
-
-    Boolean system;
+    @JsonProperty("state_info")
+    String stateInfo;
 
     @Override
     public String getId() {
@@ -45,13 +44,13 @@ public abstract class BaseDefinition implements Definition {
     }
 
     @Override
-    public String getName() {
-        return name;
+    public String getDescription() {
+        return description;
     }
 
     @Override
-    public String getDefinition() {
-        return definition;
+    public String getWorkflowName() {
+        return wfName;
     }
 
     public Date getCreatedAt() {
@@ -63,37 +62,32 @@ public abstract class BaseDefinition implements Definition {
     }
 
     @Override
-    public Boolean isSystem() {
-        return system;
-    }
-
-    @Override
     public List<String> getTags() {
         return tags;
     }
 
     @Override
-    public Scope getScope() {
-        return scope;
+    public State getState() {
+        return state;
     }
 
     @Override
-    public String getProjectId() {
-        return projectId;
+    public String getStateInfo() {
+        return stateInfo;
     }
 
     /**
-     * Base definition builder.
+     * Base execution builder.
      *
      * @author Renat Akhmerov
      */
     @SuppressWarnings("unchecked")
-    public static abstract class BaseDefinitionBuilder<T extends DefinitionBuilder<T, M>, M extends BaseDefinition>
-            implements DefinitionBuilder<T, M> {
+    public static abstract class BaseExecutionBuilder<T extends ExecutionBuilder<T, M>, M extends BaseExecution>
+            implements ExecutionBuilder<T, M> {
 
         protected M model;
 
-        BaseDefinitionBuilder(M model) {
+        BaseExecutionBuilder(M model) {
             this.model = model;
         }
 
@@ -101,7 +95,7 @@ public abstract class BaseDefinition implements Definition {
             return model;
         }
 
-        public T from(Definition in) {
+        public T from(Execution in) {
             return null;
         }
 
@@ -111,32 +105,26 @@ public abstract class BaseDefinition implements Definition {
             return (T) this;
         }
 
-        public T name(String name) {
-            model.name = name;
+        public T description(String description) {
+            model.description = description;
 
             return (T) this;
         }
 
-        public T definition(String definition) {
-            model.definition = definition;
+        public T workflowName(String wfName) {
+            model.wfName = wfName;
 
             return (T) this;
         }
 
-        public T created(Date create) {
-            model.createdAt = create;
+        public T createdAt(Date createdAt) {
+            model.createdAt = createdAt;
 
             return (T) this;
         }
 
-        public T updated(Date updated) {
-            model.updatedAt = updated;
-
-            return (T) this;
-        }
-
-        public T system(Boolean system) {
-            model.system = system;
+        public T updatedAt(Date updatedAt) {
+            model.updatedAt = updatedAt;
 
             return (T) this;
         }
@@ -147,17 +135,16 @@ public abstract class BaseDefinition implements Definition {
             return (T) this;
         }
 
-        public T scope(Scope scope) {
-            model.scope = scope;
+        public T state(State state) {
+            model.state = state;
 
             return (T) this;
         }
 
-        public T projectId(String projectId) {
-            model.projectId = projectId;
+        public T stateInfo(String stateInfo) {
+            model.stateInfo = stateInfo;
 
             return (T) this;
         }
     }
-
 }

--- a/core/src/main/java/org/openstack4j/openstack/workflow/domain/MistralWorkflowExecution.java
+++ b/core/src/main/java/org/openstack4j/openstack/workflow/domain/MistralWorkflowExecution.java
@@ -1,0 +1,134 @@
+package org.openstack4j.openstack.workflow.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import org.openstack4j.model.workflow.WorkflowExecution;
+import org.openstack4j.model.workflow.builder.WorkflowExecutionBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mistral workflow execution.
+ * 
+ * @author Renat Akhmerov
+ */
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class MistralWorkflowExecution extends BaseExecution implements WorkflowExecution {
+
+	private static final long serialVersionUID = 1L;
+
+    @JsonProperty("params")
+	private Map<String, Object> parameters;
+
+	@JsonProperty("input")
+	private Map<String, Object> input;
+
+	private Map<String, Object> output;
+
+	private String taskExecutionId;
+
+	public static MistralWorkflowExecutionBuilder builder() {
+		return new MistralWorkflowExecutionBuilder();
+	}
+	
+	@Override
+	public MistralWorkflowExecutionBuilder toBuilder() {
+		return new MistralWorkflowExecutionBuilder(this);
+	}
+
+	@Override
+	public Map<String, Object> getParameters() {
+		return parameters;
+	}
+
+	@Override
+	public Map<String, Object> getInput() {
+		return input;
+	}
+
+    @Override
+	public Map<String, Object> getOutput() {
+		return output;
+	}
+
+	@Override
+	public String getTaskExecutionId() {
+		return taskExecutionId;
+	}
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("createdAt", createdAt)
+                .add("updatedAt", updatedAt)
+                .add("id", id)
+                .add("input", input)
+                .toString();
+    }
+
+    /**
+	 * Mistral workflow execution builder.
+	 *
+	 * @author Renat Akhmerov
+	 */
+	public static class MistralWorkflowExecutionBuilder extends
+			BaseExecutionBuilder<MistralWorkflowExecutionBuilder, MistralWorkflowExecution>
+			implements WorkflowExecutionBuilder<MistralWorkflowExecutionBuilder, MistralWorkflowExecution> {
+
+		public MistralWorkflowExecutionBuilder() {
+			this(new MistralWorkflowExecution());
+		}
+
+        public MistralWorkflowExecutionBuilder(MistralWorkflowExecution model) {
+			super(model);
+		}
+
+		@Override
+		public MistralWorkflowExecutionBuilder from(MistralWorkflowExecution in) {
+			return null;
+		}
+
+		@Override
+		public MistralWorkflowExecutionBuilder parameters(Map<String, Object> parameters) {
+            this.model.parameters = parameters;
+
+			return this;
+		}
+
+		@Override
+		public MistralWorkflowExecutionBuilder input(Map<String, Object> input) {
+			this.model.input = input;
+
+			return this;
+		}
+
+		@Override
+		public MistralWorkflowExecutionBuilder output(Map<String, Object> output) {
+			this.model.output = output;
+
+			return this;
+		}
+
+		@Override
+		public MistralWorkflowExecutionBuilder taskExecutionId(String taskExecutionId) {
+			this.model.taskExecutionId = taskExecutionId;
+
+			return this;
+		}
+	}
+
+	public static class MistralWorkflowExecutions extends ListResult<MistralWorkflowExecution> {
+		private static final long serialVersionUID = 1L;
+
+		@JsonProperty("executions")
+		private List<MistralWorkflowExecution> list;
+
+		@Override
+		protected List<MistralWorkflowExecution> value() {
+			return this.list;
+		}
+	}
+}

--- a/core/src/main/java/org/openstack4j/openstack/workflow/internal/WorkflowExecutionServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/workflow/internal/WorkflowExecutionServiceImpl.java
@@ -1,0 +1,47 @@
+package org.openstack4j.openstack.workflow.internal;
+
+import org.openstack4j.api.workflow.WorkflowExecutionService;
+import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.workflow.WorkflowExecution;
+import org.openstack4j.openstack.workflow.domain.MistralWorkflowExecution;
+import org.openstack4j.openstack.workflow.domain.MistralWorkflowExecution.MistralWorkflowExecutions;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Workflow execution service implementation.
+ *
+ * @author Renat Akhmerov
+ */
+public class WorkflowExecutionServiceImpl extends BaseMistralService implements WorkflowExecutionService {
+
+    @Override
+    public List<? extends WorkflowExecution> list() {
+        return get(MistralWorkflowExecutions.class, uri("/executions")).execute().getList();
+    }
+
+    @Override
+    public WorkflowExecution create(WorkflowExecution wfExec) {
+        checkNotNull(wfExec);
+
+        Invocation<MistralWorkflowExecution> invocation = post(
+                MistralWorkflowExecution.class,
+                uri("/executions")
+        );
+
+        return invocation.entity(wfExec).execute();
+    }
+
+    @Override
+    public WorkflowExecution get(String identifier) {
+        return get(MistralWorkflowExecution.class, uri("/executions/%s", identifier)).execute();
+    }
+
+    @Override
+    public ActionResponse delete(String identifier) {
+        return deleteWithResponse(uri("/executions/%s", identifier)).execute();
+    }
+
+}


### PR DESCRIPTION
* Made ActionResponse able to various 2xx HTTP codes, not only 200
    ** Added one more static method ActionResponse.actionSuccess() taking
      an integer code
    ** Fixed deletion tests for workflow, workbook and actions definitions
      to expect 204 code. 200 was expected due to aforementioned limitation
* Added an endpoint for Mistral workflow executions