### PR TITLE
Renamed CinderVolume properties to be compatible with block storage API v2, fixed broken VolumeTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pom-shade.xml
 *.versionsBackup
 */bin/*
 *.iml
+*.ipr
+*.iws

--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -63,6 +63,8 @@ public class VolumeTests extends AbstractTest {
         assertTrue(getRequest.getPath().matches("/v[12]/\\p{XDigit}*/volumes/8a9287b7-4f4d-4213-8d75-63470f19f27c"));
         
         assertEquals(volume.getId(), "8a9287b7-4f4d-4213-8d75-63470f19f27c");
+        assertEquals(volume.getDisplayName(), "vol-test");
+        assertEquals(volume.getDisplayDescription(), "a description");
         assertNotNull(volume.getCreated());
         assertEquals(volume.getZone(), "nova");
         assertEquals(volume.getSize(), 100);

--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -63,8 +63,6 @@ public class VolumeTests extends AbstractTest {
         assertTrue(getRequest.getPath().matches("/v[12]/\\p{XDigit}*/volumes/8a9287b7-4f4d-4213-8d75-63470f19f27c"));
         
         assertEquals(volume.getId(), "8a9287b7-4f4d-4213-8d75-63470f19f27c");
-        assertEquals(volume.getName(), "vol-test");
-        assertEquals(volume.getDescription(), "a description");
         assertNotNull(volume.getCreated());
         assertEquals(volume.getZone(), "nova");
         assertEquals(volume.getSize(), 100);
@@ -91,7 +89,6 @@ public class VolumeTests extends AbstractTest {
     
     @SuppressWarnings("unchecked")
     @Test
-    @SkipTest(connector = ".*", issue = 395, description = "Volume attribute not recognized when using cinder v2 api")
     public void getVolumeV2() throws Exception {
         // Check get volume
         respondWith("/storage/v2/volume.json");
@@ -101,7 +98,7 @@ public class VolumeTests extends AbstractTest {
         assertTrue(getRequest.getPath().matches("/v[12]/\\p{XDigit}*/volumes/8a9287b7-4f4d-4213-8d75-63470f19f27c"));
         
         assertEquals(volume.getId(), "8a9287b7-4f4d-4213-8d75-63470f19f27c");
-        assertEquals(volume.getName(), "vol-test");
+        assertEquals(volume.getName(), "test-volume");
         assertEquals(volume.getDescription(), "a description");
         assertNotNull(volume.getCreated());
         assertEquals(volume.getZone(), "nova");

--- a/core-test/src/main/resources/storage/v2/volume.json
+++ b/core-test/src/main/resources/storage/v2/volume.json
@@ -3,7 +3,7 @@
         "status": "in-use",
         "user_id": "92ac3530a6cb4d47aa406f1c2c90fca4",
         "attachments": [{
-                "host_name": null,
+                "host_name": "myhost",
                 "device": "/dev/vdd",
                 "server_id": "eaa6a54d-35c1-40ce-831d-bb61f991e1a9",
                 "id": "8a9287b7-4f4d-4213-8d75-63470f19f27c",

--- a/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
@@ -87,9 +87,21 @@ public interface Volume extends ModelEntity, Buildable<VolumeBuilder> {
 	String getName();
 
 	/**
+	 * @return the display name of the volume
+	 */
+	@Deprecated
+	String getDisplayName();
+
+	/**
 	 * @return the description of the volume
 	 */
 	String getDescription();
+
+	/**
+	 * @return the display description of the volume
+	 */
+	@Deprecated
+	String getDisplayDescription();
 
 	/**
 	 * @return the status of the volume

--- a/core/src/main/java/org/openstack4j/model/storage/block/VolumeSnapshot.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/VolumeSnapshot.java
@@ -25,9 +25,21 @@ public interface VolumeSnapshot extends ModelEntity, Buildable<VolumeSnapshotBui
 	String getName();
 
 	/**
+	 * @return the display name of the snapshot
+	 */
+	@Deprecated
+	String getDisplayName();
+
+	/**
 	 * @return the description of the snapshot
 	 */
 	String getDescription();
+
+	/**
+	 * @return the display description of the snapshot
+	 */
+	@Deprecated
+	String getDisplayDescription();
 
 	/**
 	 * The volume identifier of an existing volume

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
@@ -29,8 +29,12 @@ public class CinderVolume implements Volume {
 	private String id;
 	@JsonProperty("name")
 	private String name;
+	@JsonProperty("display_name")
+	private String displayName;
 	@JsonProperty("description")
 	private String description;
+	@JsonProperty("display_description")
+	private String displayDescription;
 	private Status status;
 	@JsonInclude(Include.NON_DEFAULT)
 	@JsonProperty("size")
@@ -100,8 +104,24 @@ public class CinderVolume implements Volume {
 	 * {@inheritDoc}
 	 */
 	@Override
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public String getDescription() {
 		return description;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getDisplayDescription() {
+		return displayDescription;
 	}
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
@@ -27,9 +27,9 @@ public class CinderVolume implements Volume {
 	private static final long serialVersionUID = 1L;
 
 	private String id;
-	@JsonProperty("display_name")
+	@JsonProperty("name")
 	private String name;
-	@JsonProperty("display_description")
+	@JsonProperty("description")
 	private String description;
 	private Status status;
 	@JsonInclude(Include.NON_DEFAULT)

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeSnapshot.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeSnapshot.java
@@ -27,8 +27,12 @@ public class CinderVolumeSnapshot implements VolumeSnapshot {
 	private String id;
 	@JsonProperty("name")
 	private String name;
+	@JsonProperty("display_name")
+	private String displayName;
 	@JsonProperty("description")
 	private String description;
+	@JsonProperty("display_description")
+	private String displayDescription;
 	@JsonProperty("volume_id")
 	private String volumeId;
 	private Status status;
@@ -77,8 +81,24 @@ public class CinderVolumeSnapshot implements VolumeSnapshot {
 	 * {@inheritDoc}
 	 */
 	@Override
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public String getDescription() {
 		return description;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getDisplayDescription() {
+		return displayDescription;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1019. For v2/v3, getName() and getDescription() should return the correct values. For v1, it will return null as API fields since v2 are updated to `name` and `description`.