### PR TITLE
928 ceilometer statistics date parsing

### DIFF
--- a/core-test/src/main/java/org/openstack4j/openstack/common/TelemetryDateDeserializerTest.java
+++ b/core-test/src/main/java/org/openstack4j/openstack/common/TelemetryDateDeserializerTest.java
@@ -1,0 +1,61 @@
+package org.openstack4j.openstack.common;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TelemetryDateDeserializerTest {
+
+   private ObjectMapper mapper;
+   private TelemetryDateDeserializer deserializer;
+
+   @BeforeSuite
+   public void setup() {
+      mapper = new ObjectMapper();
+      deserializer = new TelemetryDateDeserializer();
+   }
+
+   @Test
+   public void testShortDateFormatDeserialize() throws JsonParseException, IOException, ParseException {
+      Date actual = deserializer.deserialize(getParser("2017-06-28T14:00:00"), mapper.getDeserializationContext());
+
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+      sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+      Date expected = sdf.parse("2017-06-28T14:00:00.000");
+
+      assertEquals(actual, expected);
+   }
+   
+   @Test
+   public void testLongDateFormatDeserialize() throws JsonParseException, IOException, ParseException {
+      Date actual = deserializer.deserialize(getParser("2017-06-28T14:00:00.123000"), mapper.getDeserializationContext());
+
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+      sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+      Date expected = sdf.parse("2017-06-28T14:00:00.123");
+
+      assertEquals(actual, expected);
+   }
+
+   private JsonParser getParser(String dateString) throws JsonParseException, IOException {
+      JsonParser parser = mapper.getFactory().createParser(new ByteArrayInputStream(String
+            .format("{\"date\":\"%s\"}", dateString).getBytes(StandardCharsets.UTF_8)));
+      parser.nextToken();
+      parser.nextToken();
+      parser.nextToken();
+      return parser;
+   }
+}

--- a/core/src/main/java/org/openstack4j/model/telemetry/SampleCriteria.java
+++ b/core/src/main/java/org/openstack4j/model/telemetry/SampleCriteria.java
@@ -37,7 +37,6 @@ public class SampleCriteria {
         }
     }
     
-   private String groupBy;
     private List<NameOpValue> params = new ArrayList<>();
     
     public static SampleCriteria create() {
@@ -107,12 +106,6 @@ public class SampleCriteria {
         return this;
     }
     
-    public SampleCriteria groupBy(String field) {
-        checkNotNull(field, "Field must not be null");
-      groupBy = field;
-        return this;
-    }
-
     /**
      * @return the criteria parameters for this query
      */
@@ -120,10 +113,6 @@ public class SampleCriteria {
         return params;
     }
     
-   public String getGroupBy() {
-        return groupBy;
-    }
-
     public static class NameOpValue {
         private final String field;
         private final Oper operator;

--- a/core/src/main/java/org/openstack4j/model/telemetry/SampleCriteria.java
+++ b/core/src/main/java/org/openstack4j/model/telemetry/SampleCriteria.java
@@ -1,12 +1,12 @@
 package org.openstack4j.model.telemetry;
 
-import com.google.common.collect.Lists;
-import org.openstack4j.openstack.internal.Parser;
+import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.openstack4j.openstack.internal.Parser;
 
 /**
  * Query options used in retreiving Samples
@@ -37,7 +37,8 @@ public class SampleCriteria {
         }
     }
     
-    private List<NameOpValue> params = Lists.newArrayList();
+   private String groupBy;
+    private List<NameOpValue> params = new ArrayList<>();
     
     public static SampleCriteria create() {
         return new SampleCriteria();
@@ -106,6 +107,12 @@ public class SampleCriteria {
         return this;
     }
     
+    public SampleCriteria groupBy(String field) {
+        checkNotNull(field, "Field must not be null");
+      groupBy = field;
+        return this;
+    }
+
     /**
      * @return the criteria parameters for this query
      */
@@ -113,6 +120,10 @@ public class SampleCriteria {
         return params;
     }
     
+   public String getGroupBy() {
+        return groupBy;
+    }
+
     public static class NameOpValue {
         private final String field;
         private final Oper operator;
@@ -121,10 +132,11 @@ public class SampleCriteria {
         NameOpValue(String field, Oper operator, Comparable<?> value) {
             this.field = field;
             this.operator = operator;
-            if (value instanceof Date) 
-                this.value = Parser.toISO8601DateFormat(Date.class.cast(value));
-            else
-                this.value = String.valueOf(value);
+            if (value instanceof Date) {
+               this.value = Parser.toISO8601DateFormat(Date.class.cast(value));
+            } else {
+               this.value = String.valueOf(value);
+            }
         }
         
         public String getField() {

--- a/core/src/main/java/org/openstack4j/model/telemetry/Statistics.java
+++ b/core/src/main/java/org/openstack4j/model/telemetry/Statistics.java
@@ -74,5 +74,5 @@ public interface Statistics extends ModelEntity {
 	/**
    * @return The group-by of the data set
    */
-	String getGroupBy();
+   String getGroupBy();
 }

--- a/core/src/main/java/org/openstack4j/model/telemetry/Statistics.java
+++ b/core/src/main/java/org/openstack4j/model/telemetry/Statistics.java
@@ -1,6 +1,7 @@
 package org.openstack4j.model.telemetry;
 
 import java.util.Date;
+import java.util.Map;
 
 import org.openstack4j.model.ModelEntity;
 
@@ -74,5 +75,5 @@ public interface Statistics extends ModelEntity {
 	/**
    * @return The group-by of the data set
    */
-   String getGroupBy();
+   Map<String, Object> getGroupBy();
 }

--- a/core/src/main/java/org/openstack4j/model/telemetry/Statistics.java
+++ b/core/src/main/java/org/openstack4j/model/telemetry/Statistics.java
@@ -1,7 +1,6 @@
 package org.openstack4j.model.telemetry;
 
 import java.util.Date;
-import java.util.Map;
 
 import org.openstack4j.model.ModelEntity;
 
@@ -75,5 +74,5 @@ public interface Statistics extends ModelEntity {
 	/**
    * @return The group-by of the data set
    */
-   Map<String, Object> getGroupBy();
+   String getGroupBy();
 }

--- a/core/src/main/java/org/openstack4j/openstack/common/TelemetryDateDeserializer.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/TelemetryDateDeserializer.java
@@ -1,0 +1,66 @@
+package org.openstack4j.openstack.common;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * The date formats returned from the OpenStack telemetry APIs can be returned in multiple formats like:
+ * "yyyy-MM-dd'T'HH:mm:ss" or "yyyy-MM-dd'T'HH:mm:ss.SSSSSS". This cannot be parsed correctly with a SimpleDateFormat,
+ * so the formats must be normalized. This date deserializer normalizes the date into "yyyy-MM-dd'T'HH:mm:ss.SSS" and
+ * then parses it into a Date.
+ *
+ * @author pdube
+ */
+public class TelemetryDateDeserializer extends StdDeserializer<Date> {
+   private static final String MILLIS_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+
+   public TelemetryDateDeserializer() {
+      this(null);
+   }
+
+   public TelemetryDateDeserializer(Class<?> vc) {
+      super(vc);
+   }
+
+   @Override
+   public Date deserialize(JsonParser jsonParser, DeserializationContext ctxt)
+         throws IOException, JsonProcessingException {
+      String date = jsonParser.getText();
+      SimpleDateFormat sdf = new SimpleDateFormat(MILLIS_DATE_FORMAT);
+      sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+      try {
+         return sdf.parse(getParseableDate(date));
+      } catch (ParseException e) {
+         throw new JsonParseException(jsonParser, "Could not process telemetry date", e);
+      }
+   }
+
+   /**
+    * Modifies the date string to have the expected date format ("yyyy-MM-dd'T'HH:mm:ss.SSS")
+    * 
+    * @param date
+    * @return the date with the correct format
+    */
+   private String getParseableDate(String date) {
+      // e.g. [ "2017-06-20 13:00:00" , "395000" ] or [] if no decimal
+      String[] sdate = date.split("\\.");
+      if (sdate.length > 1) {
+         return sdate[0] + "." + getExpectedDecimals(sdate[1]);
+      }
+      return date + ".000";
+   }
+
+   private String getExpectedDecimals(String decimals) {
+      return (decimals + "000").substring(0, 3);
+   }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
@@ -1,16 +1,12 @@
 package org.openstack4j.openstack.telemetry.domain;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Map;
-import java.util.TimeZone;
 
 import org.openstack4j.model.telemetry.Statistics;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.openstack4j.openstack.common.TelemetryDateDeserializer;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
 
 /**
@@ -19,10 +15,8 @@ import com.google.common.base.MoreObjects;
  * @author Jeremy Unruh
  */
 public class CeilometerStatistics implements Statistics {
-   private static final Logger LOG = LoggerFactory.getLogger(CeilometerStatistics.class);
-	private static final long serialVersionUID = 1L;
 
-   private static final String MILLIS_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+	private static final long serialVersionUID = 1L;
 
 	private Double avg;
 
@@ -30,14 +24,12 @@ public class CeilometerStatistics implements Statistics {
 
 	private Double duration;
 
+   @JsonDeserialize(using = TelemetryDateDeserializer.class)
 	@JsonProperty("duration_start")
-   private String durationStartStr;
-
-   @JsonProperty("duration_end")
-   private String durationEndStr;
-
 	private Date durationStart;
 	
+   @JsonDeserialize(using = TelemetryDateDeserializer.class)
+   @JsonProperty("duration_end")
 	private Date durationEnd;
 
 	private Double max;
@@ -46,22 +38,19 @@ public class CeilometerStatistics implements Statistics {
 
 	private Integer period;
 
+   @JsonDeserialize(using = TelemetryDateDeserializer.class)
    @JsonProperty("period_start")
-   private String periodStartStr;
+   private Date periodStart;
 
+   @JsonDeserialize(using = TelemetryDateDeserializer.class)
    @JsonProperty("period_end")
-   private String periodEndStr;
-
-	private Date periodStart;
-
 	private Date periodEnd;
 
 	private Double sum;
 
 	private String unit;
 
-   @JsonProperty("groupby")
-   private Map<String, Object> groupBy;
+   private String groupby;
 
 	/**
 	 * {@inheritDoc}
@@ -92,9 +81,6 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getDurationStart() {
-	   if(durationStart == null){
-         durationStart = parseDate(durationStartStr);
-	   }
 		return durationStart;
 	}
 
@@ -103,9 +89,6 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getDurationEnd() {
-      if (durationEnd == null) {
-         durationEnd = parseDate(durationEndStr);
-      }
       return durationEnd;
 	}
 
@@ -146,9 +129,6 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getPeriodStart() {
-      if (periodStart == null) {
-         periodStart = parseDate(periodStartStr);
-      }
       return periodStart;
 	}
 
@@ -157,9 +137,6 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getPeriodEnd() {
-      if (periodEnd == null) {
-         periodEnd = parseDate(periodEndStr);
-      }
 		return periodEnd;
 	}
 
@@ -175,39 +152,9 @@ public class CeilometerStatistics implements Statistics {
    * {@inheritDoc}
    */
   @Override
-   public Map<String, Object> getGroupBy() {
-      return groupBy;
+   public String getGroupBy() {
+      return groupby;
   }
-  
-  private Date parseDate(String date) {
-      SimpleDateFormat sdf = new SimpleDateFormat(MILLIS_DATE_FORMAT);
-      sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-    try {
-         return sdf.parse(getParseableDate(date));
-    } catch (ParseException e) {
-      LOG.warn("Error while parsing date", e);
-    }
-    return null;
-  }
-
-   /**
-    * Modifies the date string to have the expected date format ("yyyy-MM-dd'T'HH:mm:ss.SSS")
-    * 
-    * @param date
-    * @return the date with the correct format
-    */
-   private String getParseableDate(String date) {
-      // e.g. [ "2017-06-20 13:00:00" , "395000" ] or [] if no decimal
-      String[] sdate = date.split("\\.");
-      if (sdate.length > 1) {
-         return sdate[0] + "." + getExpectedDecimals(sdate[1]);
-      }
-      return date + ".000";
-   }
-
-   private String getExpectedDecimals(String decimals) {
-      return (decimals + "000").substring(0, 3);
-   }
 
    /**
     * {@inheritDoc}
@@ -216,10 +163,10 @@ public class CeilometerStatistics implements Statistics {
 	public String toString() {
 		return MoreObjects.toStringHelper(this).omitNullValues()
 				    .add("avg", avg).add("count", count).add("duration", duration)
-				    .add("durationStart", getDurationStart()).add("durationEnd", getDurationEnd())
+				    .add("durationStart", durationStart).add("durationEnd", durationEnd)
 				    .add("min", min).add("max", max).add("sum", sum).add("period", period)
-				    .add("periodStart", getPeriodStart()).add("periodEnd", getPeriodEnd()).add("unit", unit)
-				    .add("groupBy", groupBy)
+				    .add("periodStart", periodStart).add("periodEnd", periodEnd).add("unit", unit)
+				    .add("groupby", groupby)
 				    .toString();
 	}
 

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
@@ -43,14 +43,9 @@ public class CeilometerStatistics implements Statistics {
 	private Double min;
 
 	private Integer period;
-
    @JsonProperty("period_start")
-   private String periodStartStr;
-
-   @JsonProperty("period_end")
-   private String periodEndStr;
-
 	private Date periodStart;
+   @JsonProperty("period_end")
 	private Date periodEnd;
 
 	private Double sum;
@@ -142,9 +137,6 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getPeriodStart() {
-      if (periodStart == null) {
-         periodStart = parseDate(periodStartStr);
-      }
       return periodStart;
 	}
 
@@ -153,9 +145,6 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getPeriodEnd() {
-      if (periodEnd == null) {
-         periodEnd = parseDate(periodEndStr);
-      }
 		return periodEnd;
 	}
 

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
@@ -1,8 +1,12 @@
 package org.openstack4j.openstack.telemetry.domain;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.openstack4j.model.telemetry.Statistics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -13,8 +17,11 @@ import com.google.common.base.MoreObjects;
  * @author Jeremy Unruh
  */
 public class CeilometerStatistics implements Statistics {
-
+   private static final Logger LOG = LoggerFactory.getLogger(CeilometerStatistics.class);
 	private static final long serialVersionUID = 1L;
+
+   private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+   private static final int DATE_FORMAT_LENGTH = 23;
 
 	private Double avg;
 
@@ -23,9 +30,12 @@ public class CeilometerStatistics implements Statistics {
 	private Double duration;
 
 	@JsonProperty("duration_start")
-	private Date durationStart;
+   private String durationStartStr;
 
-	@JsonProperty("duration_end")
+   @JsonProperty("duration_end")
+   private String durationEndStr;
+
+	private Date durationStart;
 	private Date durationEnd;
 
 	private Double max;
@@ -34,17 +44,20 @@ public class CeilometerStatistics implements Statistics {
 
 	private Integer period;
 
-	@JsonProperty("period_start")
-	private Date periodStart;
+   @JsonProperty("period_start")
+   private String periodStartStr;
 
-	@JsonProperty("period_end")
+   @JsonProperty("period_end")
+   private String periodEndStr;
+
+	private Date periodStart;
 	private Date periodEnd;
 
 	private Double sum;
 
 	private String unit;
 
-	private String groupby;
+   private String groupby;
 
 	/**
 	 * {@inheritDoc}
@@ -75,6 +88,9 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getDurationStart() {
+	   if(durationStart == null){
+         durationStart = parseDate(durationStartStr);
+	   }
 		return durationStart;
 	}
 
@@ -83,12 +99,15 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getDurationEnd() {
-		return durationEnd;
+      if (durationEnd == null) {
+         durationEnd = parseDate(durationEndStr);
+      }
+      return durationEnd;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
+   /**
+    * {@inheritDoc}
+    */
 	@Override
 	public Double getMax() {
 		return max;
@@ -123,7 +142,10 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getPeriodStart() {
-		return periodStart;
+      if (periodStart == null) {
+         periodStart = parseDate(periodStartStr);
+      }
+      return periodStart;
 	}
 
 	/**
@@ -131,6 +153,9 @@ public class CeilometerStatistics implements Statistics {
 	 */
 	@Override
 	public Date getPeriodEnd() {
+      if (periodEnd == null) {
+         periodEnd = parseDate(periodEndStr);
+      }
 		return periodEnd;
 	}
 
@@ -146,9 +171,28 @@ public class CeilometerStatistics implements Statistics {
    * {@inheritDoc}
    */
   @Override
-  public String getGroupBy() {
+   public String getGroupBy() {
     return groupby;
   }
+  
+  private Date parseDate(String date) {
+    SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT);
+    try {
+      return sdf.parse(getTrimmedDate(date));
+    } catch (ParseException e) {
+      LOG.warn("Error while parsing date", e);
+    }
+    return null;
+  }
+
+   private String getTrimmedDate(String date) {
+      // convert "2017-06-19T10:00:00.395000"
+      if (date.length() > DATE_FORMAT_LENGTH) {
+         // to "2017-06-19T10:00:00.395"
+         return date.substring(0, DATE_FORMAT_LENGTH - 1);
+      }
+      return date;
+   }
 
 	/**
 	 * {@inheritDoc}
@@ -157,9 +201,9 @@ public class CeilometerStatistics implements Statistics {
 	public String toString() {
 		return MoreObjects.toStringHelper(this).omitNullValues()
 				    .add("avg", avg).add("count", count).add("duration", duration)
-				    .add("durationStart", durationStart).add("durationEnd", durationEnd)
+				    .add("durationStart", getDurationStart()).add("durationEnd", getDurationEnd())
 				    .add("min", min).add("max", max).add("sum", sum).add("period", period)
-				    .add("periodStart", periodStart).add("periodEnd", periodEnd).add("unit", unit)
+				    .add("periodStart", getPeriodStart()).add("periodEnd", getPeriodEnd()).add("unit", unit)
 				    .add("groupBy", groupby)
 				    .toString();
 	}

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
@@ -37,6 +37,7 @@ public class CeilometerStatistics implements Statistics {
    private String durationEndStr;
 
 	private Date durationStart;
+	
 	private Date durationEnd;
 
 	private Double max;
@@ -44,8 +45,10 @@ public class CeilometerStatistics implements Statistics {
 	private Double min;
 
 	private Integer period;
+
    @JsonProperty("period_start")
 	private Date periodStart;
+
    @JsonProperty("period_end")
 	private Date periodEnd;
 
@@ -194,8 +197,8 @@ public class CeilometerStatistics implements Statistics {
 				    .add("avg", avg).add("count", count).add("duration", duration)
 				    .add("durationStart", getDurationStart()).add("durationEnd", getDurationEnd())
 				    .add("min", min).add("max", max).add("sum", sum).add("period", period)
-				    .add("periodStart", getPeriodStart()).add("periodEnd", getPeriodEnd()).add("unit", unit)
-            .add("groupBy", getGroupBy())
+				    .add("periodStart", periodStart).add("periodEnd", periodEnd).add("unit", unit)
+				    .add("groupBy", groupBy)
 				    .toString();
 	}
 

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/domain/CeilometerStatistics.java
@@ -3,6 +3,7 @@ package org.openstack4j.openstack.telemetry.domain;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 
 import org.openstack4j.model.telemetry.Statistics;
 import org.slf4j.Logger;
@@ -52,7 +53,8 @@ public class CeilometerStatistics implements Statistics {
 
 	private String unit;
 
-   private String groupby;
+   @JsonProperty("groupby")
+   private Map<String, Object> groupBy;
 
 	/**
 	 * {@inheritDoc}
@@ -160,8 +162,8 @@ public class CeilometerStatistics implements Statistics {
    * {@inheritDoc}
    */
   @Override
-   public String getGroupBy() {
-    return groupby;
+   public Map<String, Object> getGroupBy() {
+      return groupBy;
   }
   
   private Date parseDate(String date) {
@@ -193,7 +195,7 @@ public class CeilometerStatistics implements Statistics {
 				    .add("durationStart", getDurationStart()).add("durationEnd", getDurationEnd())
 				    .add("min", min).add("max", max).add("sum", sum).add("period", period)
 				    .add("periodStart", getPeriodStart()).add("periodEnd", getPeriodEnd()).add("unit", unit)
-				    .add("groupBy", groupby)
+            .add("groupBy", getGroupBy())
 				    .toString();
 	}
 

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/internal/MeterServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/internal/MeterServiceImpl.java
@@ -89,16 +89,18 @@ public class MeterServiceImpl extends BaseTelemetryServices implements MeterServ
         checkNotNull(meterName);
         Invocation<CeilometerStatistics[]> invocation = get(CeilometerStatistics[].class, uri("/meters/%s/statistics", meterName))
                                                            .param(period > 0, "period", period);
-
-
-        if (criteria != null && !criteria.getCriteriaParams().isEmpty()) {
-            for (NameOpValue c : criteria.getCriteriaParams()) {
-                invocation.param(FIELD, c.getField());
-                invocation.param(OPER, c.getOperator().getQueryValue());
-                invocation.param(VALUE, c.getValue());
+        if (criteria != null) {
+            if (!criteria.getGroupBy().isEmpty()) {
+                invocation.param("groupby", criteria.getGroupBy());
+            }
+            if (!criteria.getCriteriaParams().isEmpty()) {
+                for (NameOpValue c : criteria.getCriteriaParams()) {
+                    invocation.param(FIELD, c.getField());
+                    invocation.param(OPER, c.getOperator().getQueryValue());
+                    invocation.param(VALUE, c.getValue());
+                }
             }
         }
-
         CeilometerStatistics[] stats = invocation.execute();
         return wrapList(stats);
     }

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/internal/MeterServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/internal/MeterServiceImpl.java
@@ -89,15 +89,13 @@ public class MeterServiceImpl extends BaseTelemetryServices implements MeterServ
         checkNotNull(meterName);
         Invocation<CeilometerStatistics[]> invocation = get(CeilometerStatistics[].class, uri("/meters/%s/statistics", meterName))
                                                            .param(period > 0, "period", period);
-        if (criteria != null) {
-            if (!criteria.getCriteriaParams().isEmpty()) {
-                for (NameOpValue c : criteria.getCriteriaParams()) {
-                    invocation.param(FIELD, c.getField());
-                    invocation.param(OPER, c.getOperator().getQueryValue());
-                    invocation.param(VALUE, c.getValue());
-                }
-            }
-        }
+         if (criteria != null && !criteria.getCriteriaParams().isEmpty()) {
+             for (NameOpValue c : criteria.getCriteriaParams()) {
+                 invocation.param(FIELD, c.getField());
+                 invocation.param(OPER, c.getOperator().getQueryValue());
+                 invocation.param(VALUE, c.getValue());
+             }
+         }
         CeilometerStatistics[] stats = invocation.execute();
         return wrapList(stats);
     }

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/internal/MeterServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/internal/MeterServiceImpl.java
@@ -90,9 +90,6 @@ public class MeterServiceImpl extends BaseTelemetryServices implements MeterServ
         Invocation<CeilometerStatistics[]> invocation = get(CeilometerStatistics[].class, uri("/meters/%s/statistics", meterName))
                                                            .param(period > 0, "period", period);
         if (criteria != null) {
-            if (!criteria.getGroupBy().isEmpty()) {
-                invocation.param("groupby", criteria.getGroupBy());
-            }
             if (!criteria.getCriteriaParams().isEmpty()) {
                 for (NameOpValue c : criteria.getCriteriaParams()) {
                     invocation.param(FIELD, c.getField());


### PR DESCRIPTION
Hi,

This is my first PR for openstack4j. The dates being parsed for the Statistics are not offset anymore by the microseconds as explained in #928. I am having problems running the core-tests though, each time, I am getting `Tests are skipped.` even when adding `-Dmaven.test.skip=false`

If someone could give me a hand that would be great