### PR TITLE
Added a new method createSnapshot() to invoke create image action API with metadata properties

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
@@ -6,7 +6,10 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
@@ -86,7 +89,21 @@ public class ServerTests extends AbstractTest {
         
         takeRequest();
     }
-    
+
+    @Test
+    public void createServerSnapshotWithMetadata() throws IOException, InterruptedException {
+        String serverSnapshotId = "72f759b3-2576-4bf0-9ac9-7cb4a5b9d541";
+        String serverId = "e565cbdb-8e74-4044-ba6e-0155500b2c46";
+
+        respondWith(serverSnapshotId);
+
+        Map<String, String> metadata = new HashMap<String, String>() {{ put("image_type", "image"); }};
+        String imageId = osv3().compute().servers().createSnapshot(serverId, "server-snapshot", metadata);
+        assertEquals(imageId, serverSnapshotId);
+
+        takeRequest();
+    }
+
     @Test
     public void getServerConsoleOutput() throws Exception {                
         // Get console output with explicit length

--- a/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ServerTests.java
@@ -6,7 +6,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,13 +90,25 @@ public class ServerTests extends AbstractTest {
     }
 
     @Test
-    public void createServerSnapshotWithMetadata() throws IOException, InterruptedException {
-        String serverSnapshotId = "72f759b3-2576-4bf0-9ac9-7cb4a5b9d541";
-        String serverId = "e565cbdb-8e74-4044-ba6e-0155500b2c46";
+    public void createServerSnapshotWithNoMetadata() throws Exception {
+        createServerSnapshot(null);
+    }
 
-        respondWith(serverSnapshotId);
-
+    @Test
+    public void createServerSnapshotWithMetadata() throws Exception {
         Map<String, String> metadata = new HashMap<String, String>() {{ put("image_type", "image"); }};
+        createServerSnapshot(metadata);
+    }
+
+    private void createServerSnapshot(Map<String, String> metadata) throws Exception {
+        final String serverSnapshotId = "72f759b3-2576-4bf0-9ac9-7cb4a5b9d541";
+        String serverId = "e565cbdb-8e74-4044-ba6e-0155500b2c46";
+        Map<String, String> headers = new HashMap<String, String>() {{
+            put("location", "http://127.0.0.1:9292/images/" + serverSnapshotId);
+        }};
+
+        respondWith(headers, 202);
+
         String imageId = osv3().compute().servers().createSnapshot(serverId, "server-snapshot", metadata);
         assertEquals(imageId, serverSnapshotId);
 

--- a/core/src/main/java/org/openstack4j/api/compute/ServerService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ServerService.java
@@ -159,6 +159,16 @@ public interface ServerService {
     String createSnapshot(String serverId, String snapshotName);
 
     /**
+     * Creates the snapshot from a server
+     *
+     * @param serverId the UUID of the server
+     * @param snapshotName the display name of the snapshot
+     * @param metadata the key/value properties for the snapshot
+     * @return the UUID for the resulting image snapshot
+     */
+    String createSnapshot(String serverId, String snapshotName, Map<String, String> metadata);
+
+    /**
      * Associates the specified Server Group by name to the Server by it's identifier
      * 
      * @param serverId the server identifier

--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/CreateSnapshotAction.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/CreateSnapshotAction.java
@@ -27,9 +27,18 @@ public class CreateSnapshotAction implements ServerAction {
     public CreateSnapshotAction(String name) {
         this.name = name;
     }
+
+    public CreateSnapshotAction(String name, Map<String, String> metadata) {
+        this.name = name;
+        this.metadata = metadata;
+    }
     
     public static CreateSnapshotAction create(String name) {
         return new CreateSnapshotAction(name);
+    }
+
+    public static CreateSnapshotAction create(String name, Map<String, String> metadata) {
+        return new CreateSnapshotAction(name, metadata);
     }
 
     public String getName() {

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openstack4j.openstack.compute.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.openstack4j.openstack.compute.domain.actions.CreateSnapshotAction.create;
 
 import java.util.HashMap;
 import java.util.List;
@@ -173,10 +174,22 @@ public class ServerServiceImpl extends BaseComputeServices implements ServerServ
      */
     @Override
     public String createSnapshot(String serverId, String snapshotName) {
+        return invokeCreateSnapshotAction(serverId, snapshotName, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String createSnapshot(String serverId, String snapshotName, Map<String, String> metadata) {
+        return invokeCreateSnapshotAction(serverId, snapshotName, metadata);
+    }
+
+    private String invokeCreateSnapshotAction(String serverId, String snapshotName, Map<String, String> metadata) {
         checkNotNull(serverId);
         checkNotNull(snapshotName);
-
-        HttpResponse response = invokeActionWithResponse(serverId, CreateSnapshotAction.create(snapshotName));
+        CreateSnapshotAction createSnapshotAction = metadata != null ? create(snapshotName, metadata) : create(snapshotName);
+        HttpResponse response = invokeActionWithResponse(serverId, createSnapshotAction);
         String id = null;
         if (response.getStatus() == 202) {
             String location = response.header("location");
@@ -185,7 +198,6 @@ public class ServerServiceImpl extends BaseComputeServices implements ServerServ
                 String[] s = location.split("/");
                 id = s[s.length - 1];
             }
-
         }
         response.getEntity(Void.class);
         return id;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
@@ -188,7 +188,7 @@ public class ServerServiceImpl extends BaseComputeServices implements ServerServ
     private String invokeCreateSnapshotAction(String serverId, String snapshotName, Map<String, String> metadata) {
         checkNotNull(serverId);
         checkNotNull(snapshotName);
-        CreateSnapshotAction createSnapshotAction = metadata != null ? create(snapshotName, metadata) : create(snapshotName);
+        CreateSnapshotAction createSnapshotAction = metadata != null && !metadata.isEmpty() ? create(snapshotName, metadata) : create(snapshotName);
         HttpResponse response = invokeActionWithResponse(serverId, createSnapshotAction);
         String id = null;
         if (response.getStatus() == 202) {


### PR DESCRIPTION
Openstack API to [create image](https://developer.openstack.org/api-ref/compute/?expanded=create-image-createimage-action-detail#create-image-createimage-action) allows passing optional metadata properties. Overloaded `createSnapshot()` to handle additional metadata and maintain backwards compatibility.