### PR TITLE
Update builder to set old deprecated fields to support volume creation (preserving name and description) for cinder API V1

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
@@ -293,12 +293,14 @@ public class CinderVolume implements Volume {
 		@Override
 		public VolumeBuilder name(String name) {
 			m.name = name;
+			m.displayName = name;
 			return this;
 		}
 
 		@Override
 		public VolumeBuilder description(String description) {
 			m.description = description;
+			m.displayDescription = description;
 			return this;
 		}
 

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeSnapshot.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolumeSnapshot.java
@@ -181,12 +181,14 @@ public class CinderVolumeSnapshot implements VolumeSnapshot {
 		@Override
 		public VolumeSnapshotBuilder name(String name) {
 			m.name = name;
+			m.displayName = name;
 			return this;
 		}
 
 		@Override
 		public VolumeSnapshotBuilder description(String description) {
 			m.description = description;
+			m.displayDescription = description;
 			return this;
 		}
 


### PR DESCRIPTION
Original fix in #1046 introduced a bug with V1 volume creation where new volume would result with no name or description. This is a NO-IMPACT fix to set extra fields which will be ignored for cinder API V2/V3.