### PR TITLE
Fix ETag header to match documented name: 'Etag'

### DIFF
--- a/core/src/main/java/org/openstack4j/model/storage/object/SwiftHeaders.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/SwiftHeaders.java
@@ -33,7 +33,7 @@ public final class SwiftHeaders {
     
     // Generic
     public static final String CONTENT_TYPE = "Content-Type";
-    public static final String ETAG = "ETag";
+    public static final String ETAG = "Etag";
     public static final String X_COPY_FROM = "X-Copy-From";
     public static final String CONTENT_LENGTH = "Content-Length";
     public static final String LAST_MODIFIED = "Last-Modified";


### PR DESCRIPTION
I was getting NULL out of the `getETag` method (using 3.0.3 with httpclient, targeting Rackspace). Per the [Swift API docs](https://developer.openstack.org/api-ref/object-storage/?expanded=get-object-content-and-metadata-detail), the header is `Etag`, not `ETag`, and I've confirmed with a custom build of OpenStack4J that this case change fixes the issue for me.

I believe this would resolve #994