### PR TITLE
Allow identity V3 to lookup service by name

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
@@ -132,7 +132,7 @@ public class DefaultEndpointURLResolver implements EndpointURLResolver {
         }
 
         for (org.openstack4j.model.identity.v3.Service service : token.getCatalog()) {
-            if (p.type == ServiceType.forName(service.getType())) {
+            if (p.type == ServiceType.forName(service.getType()) || p.type == ServiceType.forName(service.getName())) {
                 if (p.perspective == null) {
                     p.perspective = Facing.PUBLIC;
                 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/functions/ServiceToServiceType.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/functions/ServiceToServiceType.java
@@ -17,7 +17,10 @@ public class ServiceToServiceType implements Function<Service, ServiceType> {
 	 */
 	@Override
 	public ServiceType apply(Service input) {
-		return ServiceType.forName(input.getType());
+                ServiceType serviceType = ServiceType.forName(input.getType());
+                if (serviceType == ServiceType.UNKNOWN)
+                   serviceType = ServiceType.forName(input.getName());
+		return serviceType;
 	}
 
 }


### PR DESCRIPTION
According to the in identity V2, the service is lookup by name or by type (see [ref](https://github.com/ContainX/openstack4j/blob/d9a6417f1c33c8901cec5f3fc7b3f6caa3458fd3/core/src/main/java/org/openstack4j/openstack/identity/v2/domain/KeystoneAccess.java#L237)). However, Identity V3 lookup only by type. This PR intends to bring back the ability to lookup service by name.