### PR TITLE
Support multiattach property in volume

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -10,9 +10,11 @@ import java.util.Map;
 
 import okhttp3.mockwebserver.RecordedRequest;
 import org.openstack4j.api.AbstractTest;
+import org.openstack4j.api.Builders;
 import org.openstack4j.api.SkipTest;
 import org.openstack4j.model.storage.block.Volume;
 import org.openstack4j.model.storage.block.VolumeAttachment;
+import org.openstack4j.model.storage.block.builder.VolumeBuilder;
 import org.testng.annotations.Test;
 
 
@@ -140,5 +142,25 @@ public class VolumeTests extends AbstractTest {
         assertEquals(volumes.get(1).encrypted(), true);
         
         
+    }
+    
+    
+    @Test
+    public void CreateVolumeV2WithMultiattach() throws Exception {
+        // Check list volumes
+        respondWith("/storage/v2/createVolume-muitiattach.json");
+        
+        VolumeBuilder volumeBuilder = Builders.volume();
+		volumeBuilder.size(10);
+		volumeBuilder.name("test_openstack4j");
+		volumeBuilder.description("test");
+		volumeBuilder.multiattach(true);
+		
+		Volume volume = osv2().blockStorage().volumes().create(volumeBuilder.build());
+		        
+        assertEquals(volume.getSize(), 10);
+        assertEquals(volume.getName(), "test_openstack4j");
+        assertEquals(volume.getDescription(), "test");
+        assertEquals(volume.isMultiattach(), true);                        
     }
 }

--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -152,15 +152,15 @@ public class VolumeTests extends AbstractTest {
         
         VolumeBuilder volumeBuilder = Builders.volume();
 		volumeBuilder.size(10);
-		volumeBuilder.name("test_openstack4j");
-		volumeBuilder.description("test");
+		volumeBuilder.name("test_openstack4j");		
 		volumeBuilder.multiattach(true);
 		
 		Volume volume = osv2().blockStorage().volumes().create(volumeBuilder.build());
 		        
+		server.takeRequest();	 
+		
         assertEquals(volume.getSize(), 10);
-        assertEquals(volume.getName(), "test_openstack4j");
-        assertEquals(volume.getDescription(), "test");
+        assertEquals(volume.getName(), "test_openstack4j");        
         assertEquals(volume.isMultiattach(), true);                        
     }
 }

--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -161,6 +161,6 @@ public class VolumeTests extends AbstractTest {
 		server.takeRequest();	 
 		
         assertEquals(volume.getSize(), 10);               
-        assertEquals(volume.isMultiattach(), Boolean.TRUE);                        
+        assertEquals(volume.multiattach(), Boolean.TRUE);                        
     }
 }

--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -161,6 +161,6 @@ public class VolumeTests extends AbstractTest {
 		server.takeRequest();	 
 		
         assertEquals(volume.getSize(), 10);               
-        assertEquals(volume.isMultiattach(), true);                        
+        assertEquals(volume.isMultiattach(), Boolean.TRUE);                        
     }
 }

--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -154,8 +154,7 @@ public class VolumeTests extends AbstractTest {
 		volumeBuilder.size(10);
 		volumeBuilder.name("test_openstack4j");
 		volumeBuilder.description("test");
-		volumeBuilder.multiattach(true);
-		
+		volumeBuilder.multiattach(true);	
 		Volume volume = osv2().blockStorage().volumes().create(volumeBuilder.build());
 		        
 		server.takeRequest();	 

--- a/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/storage/VolumeTests.java
@@ -147,20 +147,20 @@ public class VolumeTests extends AbstractTest {
     
     @Test
     public void CreateVolumeV2WithMultiattach() throws Exception {
-        // Check list volumes
+
         respondWith("/storage/v2/createVolume-muitiattach.json");
         
         VolumeBuilder volumeBuilder = Builders.volume();
 		volumeBuilder.size(10);
-		volumeBuilder.name("test_openstack4j");		
+		volumeBuilder.name("test_openstack4j");
+		volumeBuilder.description("test");
 		volumeBuilder.multiattach(true);
 		
 		Volume volume = osv2().blockStorage().volumes().create(volumeBuilder.build());
 		        
 		server.takeRequest();	 
 		
-        assertEquals(volume.getSize(), 10);
-        assertEquals(volume.getName(), "test_openstack4j");        
+        assertEquals(volume.getSize(), 10);               
         assertEquals(volume.isMultiattach(), true);                        
     }
 }

--- a/core-test/src/main/resources/storage/v2/createVolume-muitiattach.json
+++ b/core-test/src/main/resources/storage/v2/createVolume-muitiattach.json
@@ -1,0 +1,12 @@
+{
+    "volume": {
+        "id" : "ac9ae248-cf21-4301-87b1-568ff20a0a02", 
+		"status" : "creating", 
+		"size" : 10, 
+		"zone" : "nova", 
+		"created" : "Wed Aug 16 13:27:14 KST 2017", 
+		"multiattach" : true, 
+		"metadata" : {}, 
+		"bootable" :  false
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
@@ -141,7 +141,7 @@ public interface Volume extends ModelEntity, Buildable<VolumeBuilder> {
 	/**
 	 * @return To enable this volume to attach
 	 */
-	Boolean isMultiattach();
+	Boolean multiattach();
 
 	/**
 	 * @return ID of source volume to clone from

--- a/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
@@ -141,7 +141,7 @@ public interface Volume extends ModelEntity, Buildable<VolumeBuilder> {
 	/**
 	 * @return To enable this volume to attach
 	 */
-	boolean isMultiattach();
+	Boolean isMultiattach();
 
 	/**
 	 * @return ID of source volume to clone from

--- a/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/Volume.java
@@ -137,6 +137,11 @@ public interface Volume extends ModelEntity, Buildable<VolumeBuilder> {
 	 * @return the image reference identifier (if an image was associated) otherwise null
 	 */
 	String getImageRef();
+	
+	/**
+	 * @return To enable this volume to attach
+	 */
+	boolean isMultiattach();
 
 	/**
 	 * @return ID of source volume to clone from

--- a/core/src/main/java/org/openstack4j/model/storage/block/builder/VolumeBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/builder/VolumeBuilder.java
@@ -58,7 +58,7 @@ public interface VolumeBuilder extends Builder<VolumeBuilder, Volume> {
 	 * @param To enable this volume to attach to more than one server set this value to true
 	 * @return VolumeBuilder
 	 */
-	VolumeBuilder multiattach(boolean multiattach);
+	VolumeBuilder multiattach(Boolean multiattach);
 	
 	/**
 	 * The size of the volume, in GB.

--- a/core/src/main/java/org/openstack4j/model/storage/block/builder/VolumeBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/builder/VolumeBuilder.java
@@ -53,6 +53,14 @@ public interface VolumeBuilder extends Builder<VolumeBuilder, Volume> {
 	VolumeBuilder imageRef(String imageRef);
 	
 	/**
+	 * To enable this volume to attach to more than one server <b>Optional</b>
+	 * 
+	 * @param To enable this volume to attach to more than one server set this value to true
+	 * @return VolumeBuilder
+	 */
+	VolumeBuilder multiattach(boolean multiattach);
+	
+	/**
 	 * The size of the volume, in GB.
 	 * 
 	 * @param size the size in GB

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
@@ -47,6 +47,8 @@ public class CinderVolume implements Volume {
 	private String volumeType;
 	@JsonProperty("imageRef")
 	private String imageRef;
+	@JsonProperty("multiattach")
+	private Boolean multiattach;
 	@JsonProperty("source_volid")
 	private String sourceVolid;
 	@JsonProperty("snapshot_id")
@@ -200,6 +202,14 @@ public class CinderVolume implements Volume {
 	 * {@inheritDoc}
 	 */
 	@Override
+	public boolean isMultiattach(){
+		return multiattach;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public String getSourceVolid() {
 		return sourceVolid;
 	}
@@ -259,7 +269,7 @@ public class CinderVolume implements Volume {
 		return MoreObjects.toStringHelper(this).omitNullValues()
 				     .add("id", id).add("name", name).add("description", description)
 				     .add("status", status).add("size", size).add("zone", zone).add("created", created)
-				     .add("volumeType", volumeType).add("imageRef", getImageRef())
+				     .add("volumeType", volumeType).add("imageRef", getImageRef()).add("multiattach", multiattach)
 				     .add("sourceVolid", sourceVolid).add("snapshotId", snapshotId).add("metadata", metadata)
 				     .add("bootable", bootable)
 				     .toString();
@@ -319,6 +329,12 @@ public class CinderVolume implements Volume {
 		@Override
 		public VolumeBuilder imageRef(String imageRef) {
 			m.imageRef = imageRef;
+			return this;
+		}
+		
+		@Override
+		public VolumeBuilder multiattach(boolean multiattach) {
+			m.multiattach = multiattach;
 			return this;
 		}
 

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
@@ -202,7 +202,7 @@ public class CinderVolume implements Volume {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public boolean isMultiattach(){
+	public Boolean isMultiattach(){
 		return multiattach;
 	}
 	
@@ -333,7 +333,7 @@ public class CinderVolume implements Volume {
 		}
 		
 		@Override
-		public VolumeBuilder multiattach(boolean multiattach) {
+		public VolumeBuilder multiattach(Boolean multiattach) {
 			m.multiattach = multiattach;
 			return this;
 		}

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderVolume.java
@@ -202,7 +202,7 @@ public class CinderVolume implements Volume {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Boolean isMultiattach(){
+	public Boolean multiattach(){
 		return multiattach;
 	}
 	


### PR DESCRIPTION
Added multiattach property when creating volume.
multiattach (Optional) : To enable this volume to attach to more than
one server, set this value to true. Default is false.