### PR TITLE
Switch to standalone snakeyaml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,7 +74,6 @@
 						</Private-Package>
 						<Import-Package>
 							!org.openstack*,
-							!com.fasterxml.jackson.dataformat.yaml.snakeyaml,
 							*
 						</Import-Package>
 						<!--
@@ -177,6 +176,12 @@
 		</pluginManagement>
 	</build>
 	<dependencies>
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>1.15</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>

--- a/core/src/main/java/org/openstack4j/openstack/heat/utils/Environment.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/utils/Environment.java
@@ -1,9 +1,9 @@
 package org.openstack4j.openstack.heat.utils;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -34,8 +34,6 @@ public class Environment {
 
     @SuppressWarnings("unchecked")
     private Map<String, String> getResourceRegistry(){
-        // FIXME find alternative implementation not importing com.fasterxml.jackson.dataformat.yaml.snakeyaml package
-        // this package is not visible in OSGi
         Yaml yaml = new Yaml();
         Map<String, Object> content = (Map<String, Object>) yaml.load(getEnvContent());
         return (Map<String, String>) content.get("resource_registry");

--- a/core/src/main/java/org/openstack4j/openstack/heat/utils/Template.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/utils/Template.java
@@ -1,11 +1,11 @@
 package org.openstack4j.openstack.heat.utils;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -45,8 +45,6 @@ public class Template {
      * Save the file name(absolute path) with file content in the files map
      */
     private void getFileContents() {
-        // FIXME find alternative implementation not importing com.fasterxml.jackson.dataformat.yaml.snakeyaml package
-        // this package is not visible in OSGi
         Yaml yaml = new Yaml();
         @SuppressWarnings("unchecked")
         Map<String, Object> content = (Map<String, Object>) yaml.load(getTplContent());


### PR DESCRIPTION
While experimenting with updating jackson version I noticed, `com.fasterxml.jackson.dataformat.yaml.snakeyaml.*` is [no longer exposed](https://github.com/FasterXML/jackson-dataformat-yaml/commit/c69224917fd235732e51c8327f23af7f7038108f) so I am switching to proper dependency which should hopefully resolve the OSGi limitation as well.