### PR TITLE
[issue 1094] Fix NPEs caused by okhttp HttpExecutorServiceImpl

### DIFF
--- a/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpExecutorServiceImpl.java
+++ b/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpExecutorServiceImpl.java
@@ -32,9 +32,11 @@ public class HttpExecutorServiceImpl implements HttpExecutorService {
         catch (ResponseException re) {
             throw re;
         }
+        catch (RuntimeException e) {
+            throw e;
+        }
         catch (Exception e) {
-            e.printStackTrace();
-            return null;
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
org.openstack4j.connectors.okhttp.HttpExecutorServiceImpl.execute(...) no longer returns null.
If it encounters an exception, it now throws.
Previously it suppressed the original exception and returned null, causing downstream code to fail with a NullPointerException.

See https://github.com/ContainX/openstack4j/issues/1094 for details.