### PR TITLE
Fix parsing error when Glance V2 image contains optional locations

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/image/v2/ImageV2Tests.java
+++ b/core-test/src/main/java/org/openstack4j/api/image/v2/ImageV2Tests.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 public class ImageV2Tests extends AbstractTest {
     private static final String IMAGES_JSON = "/image/v2/images.json";
     private static final String IMAGE_JSON = "/image/v2/image.json";
+    private static final String IMAGE_WIHT_LOCATION_JSON = "/image/v2/image-with-locations.json";
     private static final String IMAGE_UPDATE_JSON = "/image/v2/image-update.json";
     private static final String MEMBER_JSON = "/image/v2/member.json";
     private static final String MEMBER_UPDATE_JSON = "/image/v2/member-update.json";
@@ -70,6 +71,16 @@ public class ImageV2Tests extends AbstractTest {
         assertNotNull(image);
         assertNotNull(image.getId());
         assertEquals(image.getId(),id);
+    }
+    
+    public void testGetImageWithLocations() throws IOException {
+        respondWith(IMAGE_WIHT_LOCATION_JSON);
+        String id = "c73056d6-c583-4d6c-9f70-04f3bfd8dff4";
+        Image image = osv3().imagesV2().get(id);
+        assertNotNull(image);
+        assertNotNull(image.getId());
+        assertEquals(image.getId(),id);
+        assertEquals(2,image.getLocations().size());
     }
 
     public void testCreateImage() throws IOException {

--- a/core-test/src/main/resources/image/v2/image-with-locations.json
+++ b/core-test/src/main/resources/image/v2/image-with-locations.json
@@ -1,0 +1,31 @@
+{
+  "container_format": "bare",
+  "min_ram": 0,
+  "updated_at": "2017-10-05T07:37:07Z",
+  "file": "/v2/images/xxxx/file",
+  "owner": "xxxx",
+  "id": "c73056d6-c583-4d6c-9f70-04f3bfd8dff4",
+  "size": 10000,
+  "self": "/v2/images/xxxx",
+  "disk_format": "qcow2",
+  "direct_url": "rbd://xxxx/images/xxxx/snap",
+  "hw_disk_bus": "virtio",
+  "schema": "/v2/schemas/image",
+  "status": "active",
+  "tags": [],
+  "visibility": "public",
+  "locations": [{
+    "url": "rbd://xxxx/images/xxxx/snap",
+    "metadata": {}
+  }, {
+    "url": "rbd://yyyy/images/yyyy/snap",
+    "metadata": {}
+  }],
+  "min_disk": 0,
+  "virtual_size": null,
+  "name": "some-image",
+  "checksum": "xxx",
+  "created_at": "2017-10-05T07:37:00Z",
+  "hw_vif_model": "virtio",
+  "protected": false
+}

--- a/core/src/main/java/org/openstack4j/model/image/v2/Image.java
+++ b/core/src/main/java/org/openstack4j/model/image/v2/Image.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.openstack4j.common.Buildable;
 import org.openstack4j.model.common.BasicResource;
 import org.openstack4j.model.image.v2.builder.ImageBuilder;
+import org.openstack4j.openstack.image.v2.domain.GlanceImage.Location;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -188,7 +189,7 @@ public interface Image extends BasicResource, Buildable<ImageBuilder> {
      * This list appears if the show_multiple_locations option is
      * set to true in the Image service's configuration file.
      */
-    List<String> getLocations();
+    List<Location> getLocations();
 
     /**
      * @return the URL to access the image file kept in external store

--- a/core/src/main/java/org/openstack4j/openstack/image/v2/domain/GlanceImage.java
+++ b/core/src/main/java/org/openstack4j/openstack/image/v2/domain/GlanceImage.java
@@ -12,6 +12,7 @@ import org.openstack4j.model.image.v2.DiskFormat;
 import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.image.v2.builder.ImageBuilder;
 import org.openstack4j.openstack.common.ListResult;
+import org.openstack4j.openstack.common.Metadata;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -97,7 +98,7 @@ public class GlanceImage implements Image {
 
     private Long size;
 
-    private List<String> locations;
+    private List<Location> locations;
 
     @JsonProperty("direct_url")
     private String directUrl;
@@ -267,7 +268,7 @@ public class GlanceImage implements Image {
     }
 
     @Override
-    public List<String> getLocations() {
+    public List<Location> getLocations() {
         return locations;
     }
 
@@ -439,6 +440,15 @@ public class GlanceImage implements Image {
             return images;
         }
     }
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class Location {
+		@JsonProperty("url")
+		private String url;
+
+		@JsonProperty("metadata")
+		private Metadata metadat;
+	}
 
     public static class ImageConcreteBuilder extends BasicResourceBuilder<Image, ImageConcreteBuilder> implements ImageBuilder {
         private GlanceImage m;


### PR DESCRIPTION
Seeing parsing error when image from Glance V2 contains "locations"

According to [Glance API V2](https://developer.openstack.org/api-ref/image/v2/#show-image-details):

> A list of objects, each of which describes an image location. Each object contains a url key, whose value is a URL specifying a location, and a metadata key, whose value is a dict of key:value pairs containing information appropriate to the use of whatever external store is indicated by the URL.

Add a new Location object, and replace the locations from List<String> to List<Location>

```{
  "images": [{
    "container_format": "bare",
    "min_ram": 0,
    "updated_at": "2017-10-05T07:37:07Z",
    "file": "/v2/images/xxxx/file",
    "owner": "xxxx",
    "id": "xxxx",
    "size": 10000,
    "self": "/v2/images/xxxx",
    "disk_format": "qcow2",
    "direct_url": "rbd://xxxx/images/xxxx/snap",
    "hw_disk_bus": "virtio",
    "schema": "/v2/schemas/image",
    "status": "active",
    "tags": [],
    "visibility": "public",
    "locations": [{
      "url": "rbd://xxxx/images/xxxx/snap",
      "metadata": {}
    }],
    "min_disk": 0,
    "virtual_size": null,
    "name": "xxx",
    "checksum": "xxx",
    "created_at": "2017-10-05T07:37:00Z",
    "hw_vif_model": "virtio",
    "protected": false
  }],
  "schema": "/v2/schemas/images",
  "first": "/v2/images?name=aselvana-vnfd-deployment-control-function"
}