### PR TITLE
add rescue server status

### DIFF
--- a/core/src/main/java/org/openstack4j/model/compute/Server.java
+++ b/core/src/main/java/org/openstack4j/model/compute/Server.java
@@ -68,6 +68,8 @@ public interface Server extends ModelEntity {
 		SHELVED,
 		/** The server is shelved_offloaded, server removed from the hypervisor to minimize resource usage. */
 		SHELVED_OFFLOADED,
+		/** The server is in rescue mode*/
+		RESCUE,
 		/** OpenStack4j could not find a Status mapping for the current reported Status.  File an issue indicating the missing state */
 		UNRECOGNIZED;
 


### PR DESCRIPTION
According to the OpenStack documentation there is a rescue status - https://developer.openstack.org/api-guide/compute/server_concepts.html

Thus I've added this status to Server.Status enum