### PR TITLE
bux fixs: some APIs filtering only can specify one key with one value

### DIFF
--- a/core/src/main/java/org/openstack4j/api/networking/NetworkService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/NetworkService.java
@@ -11,48 +11,48 @@ import org.openstack4j.model.network.NetworkUpdate;
 
 /**
  * OpenStack (Neutron) Network based Operations
- * 
+ *
  * @author Jeremy Unruh
  */
 public interface NetworkService extends RestService {
-	
+
 	/**
 	 * @author HY(huangyi813 @ qq.com)
 	 * Lists the networks to which the current authorized tenant has access
-	 * @param filteringParams map (name, value) of filtering parameters
-	 * 
+	 * @param filteringParams map (name, list of value) of filtering parameters
+	 *
 	 * @return List of Network
 	 */
-	List<? extends Network> list(Map<String, String> filteringParams);
-	
+	List<? extends Network> list(Map<String, List<String>> filteringParams);
+
 
 	/**
 	 * Lists the networks to which the current authorized tenant has access
-	 * 
+	 *
 	 * @return List of Network
 	 */
 	List<? extends Network> list();
-	
+
 	/**
 	 * Gets the network by ID
-	 * 
+	 *
 	 * @param networkId the network identifier
 	 * @return the Network or null if not found
 	 */
 	Network get(String networkId);
-	
+
 	/**
 	 * Updates a network associated by the specified {@code networkId}
-	 * 
+	 *
 	 * @param networkId the network identifier
 	 * @param network the network options to update (see {@link Builders#networkUpdate()}
 	 * @return the updated network
 	 */
 	Network update(String networkId, NetworkUpdate network);
-	
+
 	/**
 	 * Deletes a specified network and its associated resources
-	 *  
+	 *
 	 * @param networkId the network identifier
 	 * @return the action response
 	 */
@@ -60,10 +60,10 @@ public interface NetworkService extends RestService {
 
 	/**
 	 * Creates a new Network
-	 * 
+	 *
 	 * @param network the network to create
 	 * @return the newly created network
 	 */
 	Network create(Network network);
-	
+
 }

--- a/core/src/main/java/org/openstack4j/api/networking/SecurityGroupRuleService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/SecurityGroupRuleService.java
@@ -13,14 +13,14 @@ import org.openstack4j.model.network.SecurityGroupRule;
  * @author Nathan Anderson
  */
 public interface SecurityGroupRuleService extends RestService {
-  
+
   /**
    * List security group rules accessible by current Tenant.
    *
    * @return the list<? extends security group rules>
    */
   List<? extends SecurityGroupRule> list();
-  
+
   /**
    * Gets the Security Group rule by id
    *
@@ -28,14 +28,14 @@ public interface SecurityGroupRuleService extends RestService {
    * @return the security group rule
    */
   SecurityGroupRule get(String id);
-  
+
   /**
    * Delete security group rule by id.
    *
    * @param id the id
    */
   void delete(String id);
-  
+
   /**
    * Creates a security group rule.
    *
@@ -46,10 +46,10 @@ public interface SecurityGroupRuleService extends RestService {
 
   /**
    * List security group rules accessible by current Tenant.
-   * @param filteringParams map (name, value) of filtering parameters
+   * @param filteringParams map (name, list of value) of filtering parameters
    *
    * @return the list<? extends security group rules>
    */
-  List<? extends SecurityGroupRule> list(Map<String, String> filteringParams);
-  
+  List<? extends SecurityGroupRule> list(Map<String, List<String>> filteringParams);
+
 }

--- a/core/src/main/java/org/openstack4j/api/networking/SecurityGroupService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/SecurityGroupService.java
@@ -58,9 +58,9 @@ public interface SecurityGroupService extends RestService {
 
     /**
      * Get list of security groups accessible by the current tenant
-     * @param filteringParams map (name, value) of filtering parameters
+     * @param filteringParams map (name, list of value) of filtering parameters
      *
      * @return the list<? extends security group>
      */
-    List<? extends SecurityGroup> list(Map<String, String> filteringParams);
+    List<? extends SecurityGroup> list(Map<String, List<String>> filteringParams);
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkServiceImpl.java
@@ -14,32 +14,34 @@ import org.openstack4j.openstack.networking.domain.NeutronNetwork.Networks;
 
 /**
  * OpenStack (Neutron) Network based Operations
- * 
+ *
  * @author Jeremy Unruh
  */
 public class NetworkServiceImpl extends BaseNetworkingServices implements NetworkService {
-	
-	 private Invocation<Networks> buildInvocation(Map<String, String> filteringParams) {
+
+	 private Invocation<Networks> buildInvocation(Map<String, List<String>> filteringParams) {
 	        Invocation<Networks> invocation = get(Networks.class, "/networks");
 	        if (filteringParams == null) {
 	            return invocation;
 	        } else {
-	            for (Map.Entry<String, String> entry : filteringParams.entrySet()) {
-	            	invocation = invocation.param(entry.getKey(), entry.getValue());
+	            for (Map.Entry<String, List<String>> entry : filteringParams.entrySet()) {
+	            	for (String value : entry.getValue()) {
+						invocation = invocation.param(entry.getKey(), value);
+					}
 	            }
 	        }
 	        return invocation;
 	    }
-	
-	
+
+
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public List<? extends Network> list(Map<String, String> filteringParams){
+	public List<? extends Network> list(Map<String, List<String>> filteringParams){
 		  Invocation<Networks> invocation = buildInvocation(filteringParams);
 	        return invocation.execute().getList();
-		
+
 	}
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupRuleServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupRuleServiceImpl.java
@@ -48,11 +48,13 @@ public class SecurityGroupRuleServiceImpl extends BaseNetworkingServices impleme
      * {@inheritDoc}
      */
     @Override
-    public List<? extends SecurityGroupRule> list(Map<String, String> filteringParams) {
+    public List<? extends SecurityGroupRule> list(Map<String, List<String>> filteringParams) {
         Invocation<SecurityGroupRules> securityGroupRulesInvocation = get(SecurityGroupRules.class, "/security-group-rules");
         if (filteringParams != null) {
-            for (Map.Entry<String, String> entry : filteringParams.entrySet()) {
-                securityGroupRulesInvocation = securityGroupRulesInvocation.param(entry.getKey(), entry.getValue());
+            for (Map.Entry<String, List<String>> entry : filteringParams.entrySet()) {
+                for (String value : entry.getValue()) {
+                    securityGroupRulesInvocation = securityGroupRulesInvocation.param(entry.getKey(), value);
+                }
             }
         }
         return securityGroupRulesInvocation.execute().getList();

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupServiceImpl.java
@@ -69,11 +69,13 @@ public class SecurityGroupServiceImpl extends BaseNetworkingServices implements 
      * {@inheritDoc}
      */
     @Override
-    public List<? extends SecurityGroup> list(Map<String, String> filteringParams) {
+    public List<? extends SecurityGroup> list(Map<String, List<String>> filteringParams) {
         Invocation<SecurityGroups> securityGroupInvocation = get(SecurityGroups.class, "/security-groups");
         if (filteringParams != null) {
-            for (Map.Entry<String, String> entry : filteringParams.entrySet()) {
-                securityGroupInvocation = securityGroupInvocation.param(entry.getKey(), entry.getValue());
+            for (Map.Entry<String, List<String>> entry : filteringParams.entrySet()) {
+                for (String value : entry.getValue()) {
+                    securityGroupInvocation = securityGroupInvocation.param(entry.getKey(), value);
+                }
             }
         }
         return securityGroupInvocation.execute().getList();


### PR DESCRIPTION
we can use openstack4j filter message with one key with one value
GET /v2.0/networks?name=foobar

but It won't work for
GET /v2.0/networks?name=foobar&name=bizbaz