### PR TITLE
Adding new ProjectService API for listing projects

### DIFF
--- a/core/src/main/java/org/openstack4j/api/identity/v3/ProjectService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/v3/ProjectService.java
@@ -79,4 +79,11 @@ public interface ProjectService extends RestService {
 	 */
 	List<? extends Project> list();
 
+	/**
+	 * list all projects on the certain domain the current token has access to
+	 *
+	 * @return list of projects on a certain domain
+	 */
+	List<? extends Project> list(String domainId);
+
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/ProjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/ProjectServiceImpl.java
@@ -65,4 +65,9 @@ public class ProjectServiceImpl extends BaseOpenStackService implements ProjectS
         return get(Projects.class, uri(PATH_PROJECTS)).execute().getList();
     }
 
+    @Override
+    public List<? extends Project> list(String domainId) {
+        return get(Projects.class, uri(PATH_PROJECTS)).param("domain_id", domainId).execute().getList();
+    }
+
 }


### PR DESCRIPTION
Adding new API for projects listing on certain domain
in ProjectService.

Keystone expects domain_id value in URL for domain scoped
authentication tokens to be authorized to list domain's projects.

OS4J ProjectService is not aware of the auth. token scope domain.

This patch allows to use projects list API
in a domain scope by specifying the domai_id as a parameter
in the keystone projects URL.

Link to an issue: #1122