### PR TITLE
Heat service, adding support for stack abandon and adopt 

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/heat/StackServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/heat/StackServiceTests.java
@@ -1,0 +1,51 @@
+package org.openstack4j.api.heat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.model.heat.AdoptStackData;
+import org.openstack4j.model.heat.Stack;
+import org.openstack4j.openstack.heat.domain.HeatAdoptStackData;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for Heat Stack Services function
+ *
+ * @author Ales Kemr
+ */
+@Test(suiteName="heat/stacks", enabled = true)
+public class StackServiceTests extends AbstractTest {
+
+    private static final String JSON_ABANDON = "/heat/abandon.json";
+    private static final String JSON_ADOPT = "/heat/adopt.json";
+    
+    public void testAbandonStack() throws Exception {
+        respondWith(JSON_ABANDON);
+        
+        AdoptStackData adoptStackData = osv3().heat().stacks().abandon("stack_123", "416c09e9-2022-4d43-854b-0292ddff3f5d");
+        takeRequest();
+        
+        assertEquals(adoptStackData.getName(), "stack_123");
+        assertEquals(adoptStackData.getStatus(), "COMPLETE");
+        final Map<String, Object> portResource = adoptStackData.getResources().get("network_port");
+        assertEquals(portResource.get("type"), "OS::Neutron::Port");
+    }
+    
+    public void testAdoptStack() throws Exception {
+        respondWith(JSON_ADOPT);
+        
+        AdoptStackData adoptStackData = new ObjectMapper().readValue(getResource(JSON_ABANDON), HeatAdoptStackData.class);
+        Stack adoptedStack = osv3().heat().stacks().adopt(adoptStackData, new HashMap<String, String>(), false, 30L, null);
+        takeRequest();
+        
+        assertEquals(adoptedStack.getId(), "79370050-6038-4ea2-baaa-3e4706d59e0e");
+    }
+
+    @Override
+    protected Service service() {
+        return Service.ORCHESTRATION;
+    }
+
+}

--- a/core-test/src/main/resources/heat/abandon.json
+++ b/core-test/src/main/resources/heat/abandon.json
@@ -1,0 +1,55 @@
+{
+   "files":{
+
+   },
+   "status":"COMPLETE",
+   "name":"stack_123",
+   "tags":null,
+   "stack_user_project_id":"44ed5c0be2384092b8e8b6444812db5d",
+   "environment":{
+      "event_sinks":[
+
+      ],
+      "parameter_defaults":{
+
+      },
+      "parameters":{
+
+      },
+      "resource_registry":{
+         "resources":{
+
+         }
+      }
+   },
+   "template":{
+      "heat_template_version":"2016-04-08",
+      "description":"A heat test template",
+      "resources":{
+         "network_port":{
+            "type":"OS::Neutron::Port",
+            "properties":{
+               "network_id":"network123"
+            }
+         }
+      }
+   },
+   "action":"CREATE",
+   "project_id":"0dbd25a2a75347cf88a0a52638b8fff3",
+   "id":"416c09e9-2022-4d43-854b-0292ddff3f5d",
+   "resources":{
+      "network_port":{
+         "status":"COMPLETE",
+         "name":"network_port",
+         "resource_data":{
+
+         },
+         "resource_id":"1d0dccbb-0c99-48cd-b41b-abeca3ac6a42",
+         "action":"CREATE",
+         "type":"OS::Neutron::Port",
+         "metadata":{
+
+         }
+      }
+   }
+}

--- a/core-test/src/main/resources/heat/adopt.json
+++ b/core-test/src/main/resources/heat/adopt.json
@@ -1,0 +1,11 @@
+{
+   "stack":{
+      "id":"79370050-6038-4ea2-baaa-3e4706d59e0e",
+      "links":[
+         {
+            "href":"http://any.os.com:8004/v1/0dbd25a2a75347cf88a0a52638b8fff3/stacks/stack_123/79370050-6038-4ea2-baaa-3e4706d59e0e",
+            "rel":"self"
+         }
+      ]
+   }
+}

--- a/core/src/main/java/org/openstack4j/api/heat/StackService.java
+++ b/core/src/main/java/org/openstack4j/api/heat/StackService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.heat.AdoptStackData;
 import org.openstack4j.model.heat.Stack;
 import org.openstack4j.model.heat.StackCreate;
 import org.openstack4j.model.heat.StackUpdate;
@@ -100,5 +101,26 @@ public interface StackService {
 	 */
 	ActionResponse delete(String stackName, String stackId);
 
-
+        /**
+         * Deletes a stack but leaves its resources intact, and returns data that describes the stack and its resources.
+         * 
+         * @param stackName Name of {@link Stack}
+         * @param stackId Id of {@link Stack}
+         * 
+         * @return <code>adopt_stack_data</code> element representing by {@link AdoptStackData}
+         */
+        AdoptStackData abandon(String stackName, String stackId);
+        
+        /**
+         * Creates a stack from existing resources.
+         * 
+         * @param adoptStackData Structure {@link AdoptStackData}, representing existing resources
+         * @param parameters Map of parameters
+         * @param disableRollback Enable or disable rollback
+         * @param timeOutMins Timeout in minutes
+         * @param template Template in Json-Format or YAML format. It is optional, used just in case there will be new resources (not included in adoptStackData)
+         * @return 
+         */
+        Stack adopt(AdoptStackData adoptStackData, Map<String, String> parameters,
+			boolean disableRollback, Long timeOutMins, String template);
 }

--- a/core/src/main/java/org/openstack4j/model/heat/AdoptStackData.java
+++ b/core/src/main/java/org/openstack4j/model/heat/AdoptStackData.java
@@ -1,0 +1,59 @@
+package org.openstack4j.model.heat;
+
+import java.util.Map;
+import org.openstack4j.model.ModelEntity;
+
+/**
+ * This interface describes <code>adopt_stack_data</code> element. It is used
+ * for stack adoption and as a return value for stack abandoning. All getters
+ * map to the possible return values of
+ * <code> Delete /v1/{tenant_id}/stacks/{stack_name}/{stack_id}/abandon</code>
+ *
+ * @see https://developer.openstack.org/api-ref/orchestration/v1
+ *
+ * @author Ales Kemr
+ */
+public interface AdoptStackData extends ModelEntity {
+
+    /**
+     * Returns stack action, e.g. CREATE
+     * 
+     * @return stack action
+     */
+    String getAction();
+
+    /**
+     * Returns the id of the stack
+     *
+     * @return the id of the stack
+     */
+    String getId();
+
+    /**
+     * Returns the name of the stack
+     *
+     * @return the name of the stack
+     */
+    String getName();
+
+    /**
+     * Returns the status of the stack
+     *
+     * @return the status of the stack
+     */
+    String getStatus();
+
+    /**
+     * Returns stack template as a map
+     *
+     * @return stack template as a map
+     */
+    Map<String, Object> getTemplate();
+
+    /**
+     * Returns map of existing resources, to be adopted into the stack
+     *
+     * @return Map of existing resources to be adopted into the stack
+     */
+    Map<String, Map<String, Object>> getResources();
+}

--- a/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
@@ -2,6 +2,7 @@ package org.openstack4j.openstack.heat.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.util.Map;
 import org.openstack4j.model.heat.AdoptStackData;
 
@@ -65,7 +66,12 @@ public class HeatAdoptStackData implements AdoptStackData {
 
     @Override
     public String toString() {
-        return "HeatAdoptStackData{" + "id=" + id + ", name=" + name + ", status=" + status + ", resources=" + resources + '}';
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                .add("id", id)
+                .add("name", name)
+                .add("status", status)
+                .add("resources", resources)
+                .toString();
     }
 
     public static HeatAdoptStackDataBuilder builder() {

--- a/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
@@ -1,0 +1,123 @@
+package org.openstack4j.openstack.heat.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import org.openstack4j.model.heat.AdoptStackData;
+
+/**
+ * This class contains all elements required for the creation of <code>adopt_stack_data</code> element. It is used for stack adoption and as a return value for stack abandoning.
+ * It uses Jackson annotation for (de)serialization into JSON.
+ * 
+ * @author Ales Kemr
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HeatAdoptStackData implements AdoptStackData {
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("action")
+    private String action;
+    
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("name")
+    private String name;
+    
+    @JsonProperty("status")
+    private String status;
+    
+    @JsonProperty("template")
+    private Map<String,Object> template;
+    
+    @JsonProperty("resources")
+    private Map<String, Map<String, Object>> resources;
+
+    @Override
+    public String getAction() {
+        return action;
+    }
+    
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getStatus() {
+        return status;
+    }
+
+    @Override
+    public Map<String,Object> getTemplate() {
+        return template;
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getResources() {
+        return resources;
+    }
+
+    @Override
+    public String toString() {
+        return "HeatAdoptStackData{" + "id=" + id + ", name=" + name + ", status=" + status + ", resources=" + resources + '}';
+    }
+
+    public static HeatAdoptStackDataBuilder builder() {
+        return new HeatAdoptStackDataBuilder();
+    }
+
+    public static class HeatAdoptStackDataBuilder {
+
+        private HeatAdoptStackData model;
+
+        public HeatAdoptStackDataBuilder() {
+            this.model = new HeatAdoptStackData();
+        }
+
+        public HeatAdoptStackDataBuilder(HeatAdoptStackData model) {
+            this.model = model;
+        }
+
+        public HeatAdoptStackDataBuilder action(String action) {
+            this.model.action = action;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder id(String id) {
+            this.model.id = id;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder name(String name) {
+            this.model.name = name;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder status(String status) {
+            this.model.status = status;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder template(Map<String,Object> template) {
+            this.model.template = template;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder resources(Map<String, Map<String, Object>> resources) {
+            this.model.resources = resources;
+            return this;
+        }
+
+        public HeatAdoptStackData build() {
+            return model;
+        }
+    }
+
+    
+}

--- a/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatStackAdopt.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatStackAdopt.java
@@ -1,0 +1,116 @@
+package org.openstack4j.openstack.heat.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.heat.AdoptStackData;
+
+/**
+ * This class contains all elements required for the adoption of a HeatStack. It
+ * uses Jackson annotation for (de)serialization into JSON
+ * 
+ * @author Ales Kemr
+ */
+public class HeatStackAdopt implements ModelEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("stack_name")
+    private String name;
+    @JsonProperty("timeout_mins")
+    private Long timeoutMins;
+    @JsonProperty("parameters")
+    private Map<String, String> parameters;
+    @JsonProperty("disable_rollback")
+    private boolean disableRollback;
+    @JsonProperty("adopt_stack_data")
+    private String adoptStackData;
+    @JsonProperty("template")
+    private String template;
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getTimeoutMins() {
+        return timeoutMins;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public boolean isDisableRollback() {
+        return disableRollback;
+    }
+
+    public String getAdoptStackData() {
+        return adoptStackData;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+    
+    public static HeatStackAdoptBuilder builder() {
+        return new HeatStackAdoptBuilder();
+    }
+
+    public static class HeatStackAdoptBuilder {
+
+        private HeatStackAdopt model;
+
+        public HeatStackAdoptBuilder(HeatStackAdopt model) {
+            this.model = model;
+        }
+
+        public HeatStackAdoptBuilder() {
+            this.model = new HeatStackAdopt();
+        }
+        
+        public HeatStackAdoptBuilder name(String name) {
+            this.model.name = name;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder timeoutMins(Long timeoutMins) {
+            this.model.timeoutMins = timeoutMins;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder parameters(Map<String, String> parameters) {
+            this.model.parameters = parameters;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder disableRollback(boolean disableRollback) {
+            this.model.disableRollback = disableRollback;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder adoptStackData(AdoptStackData adoptStackData) {
+            try {
+                this.model.adoptStackData = new ObjectMapper().writeValueAsString(adoptStackData);
+                return this;
+            } catch (JsonProcessingException ex) {
+                Logger.getLogger(HeatStackAdopt.class.getName()).log(Level.SEVERE, null, ex);
+                throw new RuntimeException(ex);
+            }
+        }
+        
+        public HeatStackAdoptBuilder template(String template) {
+            this.model.template = template;
+            return this;
+        }
+
+        public HeatStackAdopt build() {
+            return model;
+        }
+    }
+    
+    
+}

--- a/core/src/main/java/org/openstack4j/openstack/heat/internal/StackServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/internal/StackServiceImpl.java
@@ -3,11 +3,14 @@ package org.openstack4j.openstack.heat.internal;
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.heat.StackService;
 import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.heat.AdoptStackData;
 import org.openstack4j.model.heat.Stack;
 import org.openstack4j.model.heat.StackCreate;
 import org.openstack4j.model.heat.StackUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
+import org.openstack4j.openstack.heat.domain.HeatAdoptStackData;
 import org.openstack4j.openstack.heat.domain.HeatStack;
+import org.openstack4j.openstack.heat.domain.HeatStackAdopt;
 import org.openstack4j.openstack.heat.domain.HeatStack.Stacks;
 
 import java.util.List;
@@ -90,4 +93,26 @@ public class StackServiceImpl extends BaseHeatServices implements StackService {
         checkNotNull(stackName);
         return get(HeatStack.class, uri("/stacks/%s", stackName)).execute();
     }
+    
+    @Override
+    public AdoptStackData abandon(String stackName, String stackId) {
+        checkNotNull(stackId);
+        return delete(HeatAdoptStackData.class, uri("/stacks/%s/%s/abandon", stackName, stackId)).execute();
+    }
+
+    @Override
+    public Stack adopt(AdoptStackData adoptStackData, Map<String, String> parameters, boolean disableRollback, Long timeoutMins, String template) {
+        checkNotNull(adoptStackData);
+        checkNotNull(parameters);
+        checkNotNull(timeoutMins);
+        HeatStackAdopt heatStackAdopt = HeatStackAdopt.builder()
+                .adoptStackData(adoptStackData)
+                .template(template)
+                .disableRollback(disableRollback)
+                .name(adoptStackData.getName())
+                .parameters(parameters)
+                .timeoutMins(timeoutMins)
+                .build();
+        return post(HeatStack.class, uri("/stacks")).entity(heatStackAdopt).execute();
+    }    
 }


### PR DESCRIPTION
Implements issue #1135. 

There are 2 new methods in `heat.StackService`: abandon and adopt. New interface `AdoptStackData` describes `adopt_stack_data` element, used as an input for stack adoption and as a return value for stack abandoning.

Basic unit tests are included. The code was tested against real Openstack instance as well.