### PR TITLE
Make sure the number of okhttp CLOSE_WAIT connections is always manageable

### DIFF
--- a/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpExecutorServiceImpl.java
+++ b/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpExecutorServiceImpl.java
@@ -29,9 +29,6 @@ public class HttpExecutorServiceImpl implements HttpExecutorService {
         try {
             return invoke(request);
         }
-        catch (ResponseException re) {
-            throw re;
-        }
         catch (RuntimeException e) {
             throw e;
         }

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -73,6 +73,17 @@
 		</dependency>
 	</dependencies>
 
+	<repositories>
+		<repository>
+			<!-- betamax snapshots -->
+			<id>sonatype-snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
I have observed in production 2500ish openstack connections in `CLOSE_WAIT` state that took several minutes to get properly closed (by `ConnectionPool#cleanup()`). I turned out every interaction with openstack creates separate `OkHttpClient` instance which is discouraged so dedicated auto-cleaned connection pools have no chance to have any positive effect. I am not convinced it is wise to share the client/connectionpool for the `HttpExecutorServiceImpl` so I am settling with the eager resource cleanup.

I have retested this change via jenkinsci/openstack-cloud-plugin and the interaction that used to create 100+ connection that took a while to be released, this hardly ever create more than 5 at the same time.