### PR TITLE
Cache maven artifact directory to enable faster builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+# Cache maven cache directory so external artifacts dont need to be
+# re-downloaded.
+cache:
+  directories:
+  - $HOME/.m2
+
 language: java
 
 jdk:


### PR DESCRIPTION
Cache the m2 directory so artifacts dont need to be downloaded multiple times.

https://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies)