### PR TITLE
Consider the SSLContext of an HttpRequest's Config object when using the Resteasy connector

### DIFF
--- a/connectors/resteasy/src/main/java/org/openstack4j/connectors/resteasy/executors/ApacheHttpClientEngine.java
+++ b/connectors/resteasy/src/main/java/org/openstack4j/connectors/resteasy/executors/ApacheHttpClientEngine.java
@@ -49,6 +49,10 @@ public class ApacheHttpClientEngine extends ApacheHttpClient4Engine {
             httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
         }
 
+        if (config.getSslContext() != null) {
+            httpClientBuilder.setSSLContext(config.getSslContext());
+        }
+
         if (config.getHostNameVerifier() != null) {
             httpClientBuilder.setSSLHostnameVerifier(config.getHostNameVerifier());
         }


### PR DESCRIPTION
The SSLContext of an HttpRequest was not passed to the HttpClientBuilder in the ApacheHttpClientEngine. This closes #1161.