### PR TITLE
Fix issue #1165.

### DIFF
--- a/connectors/httpclient/src/main/java/org/openstack4j/connectors/httpclient/HttpExecutorServiceImpl.java
+++ b/connectors/httpclient/src/main/java/org/openstack4j/connectors/httpclient/HttpExecutorServiceImpl.java
@@ -70,10 +70,10 @@ public class HttpExecutorServiceImpl implements HttpExecutorService {
             {
                 OSAuthenticator.reAuthenticate();
                 command.getRequest().getHeaders().put(ClientConstants.HEADER_X_AUTH_TOKEN, OSClientSession.getCurrent().getTokenId());
-                return invokeRequest(command.incrementRetriesAndReturn());
             } finally {
                 response.close();
             }
+            return invokeRequest(command.incrementRetriesAndReturn());
         }
 
         return HttpResponseImpl.wrap(response);


### PR DESCRIPTION
Moved the return method after the finally block thus guaranteeing that the initial connection is always closed before the recursive invocation.