### PR TITLE
Checking for null values in chaining method calls

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -222,7 +222,7 @@ public class BaseOpenStackService {
             }
              
             reqIdContainer.set(reqId);
-            return checkNotNull(res.getEntity(request.getReturnType(), options));
+            return res.getEntity(request.getReturnType(), options);
         }
 
         public HttpResponse executeWithResponse() {

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -28,7 +28,7 @@ import org.openstack4j.model.identity.v3.Service;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BaseOpenStackService {
 
@@ -222,7 +222,7 @@ public class BaseOpenStackService {
             }
              
             reqIdContainer.set(reqId);
-            return res.getEntity(request.getReturnType(), options);
+            return checkNotNull(res.getEntity(request.getReturnType(), options));
         }
 
         public HttpResponse executeWithResponse() {

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/PortServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/PortServiceImpl.java
@@ -24,7 +24,7 @@ public class PortServiceImpl extends BaseNetworkingServices implements PortServi
      */
     @Override
     public List<? extends Port> list() {
-        return get(Ports.class, uri("/ports")).execute().getList();
+        return checkNotNull(get(Ports.class, uri("/ports")).execute()).getList();
     }
 
     @Override
@@ -32,7 +32,7 @@ public class PortServiceImpl extends BaseNetworkingServices implements PortServi
         if (options == null)
             return list();
         
-        return get(Ports.class, uri("/ports")).params(options.getOptions()).execute().getList();
+        return checkNotNull(get(Ports.class, uri("/ports")).params(options.getOptions()).execute()).getList();
     }
 
     /**
@@ -72,8 +72,8 @@ public class PortServiceImpl extends BaseNetworkingServices implements PortServi
         for (Port port : ports) {
             checkNotNull(port.getNetworkId(), "NetworkId is a required field");
         }
-        return post(Ports.class, uri("/ports")).entity(NeutronPortCreate.NeutronPortsCreate.fromPorts(ports))
-                .execute().getList();
+        return checkNotNull(post(Ports.class, uri("/ports")).entity(NeutronPortCreate.NeutronPortsCreate.fromPorts(ports))
+                .execute()).getList();
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FlowClassifierServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FlowClassifierServiceImpl.java
@@ -21,7 +21,7 @@ public class FlowClassifierServiceImpl extends BaseNetworkingServices implements
      */
     @Override
     public List<? extends FlowClassifier> list() {
-        return get(FlowClassifiers.class, uri("/sfc/flow_classifiers")).execute().getList();
+        return checkNotNull(get(FlowClassifiers.class, uri("/sfc/flow_classifiers")).execute()).getList();
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/PortChainServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/PortChainServiceImpl.java
@@ -21,7 +21,7 @@ public class PortChainServiceImpl extends BaseNetworkingServices implements Port
      */
     @Override
     public List<? extends PortChain> list() {
-        return get(PortChains.class, uri("/sfc/port_chains")).execute().getList();
+        return checkNotNull(get(PortChains.class, uri("/sfc/port_chains")).execute()).getList();
     }
 
     /**

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/PortPairGroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/PortPairGroupServiceImpl.java
@@ -21,7 +21,7 @@ public class PortPairGroupServiceImpl extends BaseNetworkingServices implements 
      */
     @Override
     public List<? extends PortPairGroup> list() {
-        return get(PortPairGroups.class, uri("/sfc/port_pair_groups")).execute().getList();
+        return checkNotNull(get(PortPairGroups.class, uri("/sfc/port_pair_groups")).execute()).getList();
     }
 
     /**


### PR DESCRIPTION
There are few chaining method calls in services implementation classes, such as `get(PortChains.class, uri("/sfc/port_chains")).execute()).getList();` where the execute() call may return null, Its better that the call get fail early if the null is returned by execute call and make debug easier.

