### PR TITLE
member of extra field in KeystoneProject(v3) should be Object Type

### DIFF
--- a/core/src/main/java/org/openstack4j/model/identity/v3/Project.java
+++ b/core/src/main/java/org/openstack4j/model/identity/v3/Project.java
@@ -8,7 +8,7 @@ import org.openstack4j.model.identity.v3.builder.ProjectBuilder;
 
 /**
  * Project Model class use to group/isolate resources and/or identity objects
- * 
+ *
  * @see <a href="http://developer.openstack.org/api-ref-identity-v3.html#projects-v3">API reference</a>
  */
 public interface Project extends ModelEntity, Buildable<ProjectBuilder> {
@@ -26,7 +26,7 @@ public interface Project extends ModelEntity, Buildable<ProjectBuilder> {
     String getDomainId();
 
     /**
-     * 
+     *
      * @return the domain
      */
     Domain getDomain();
@@ -37,37 +37,37 @@ public interface Project extends ModelEntity, Buildable<ProjectBuilder> {
     String getDescription();
 
     /**
-     * 
+     *
      * @return the Name of the project
      */
     String getName();
 
     /**
-     * 
+     *
      * @return the links of the project
      */
     Map<String, String> getLinks();
 
     /**
-     * 
+     *
      * @return the parentId of the project
      */
     String getParentId();
 
     /**
-     * 
+     *
      * @return the subtree of the project
      */
     String getSubtree();
 
     /**
-     * 
+     *
      * @return the parents of the project
      */
     String getParents();
 
     /**
-     * 
+     *
      * @return if the project is enabled
      */
     boolean isEnabled();
@@ -76,5 +76,5 @@ public interface Project extends ModelEntity, Buildable<ProjectBuilder> {
      *
      * @return value for the given key
      */
-    String getExtra(String key);
+    Object getExtra(String key);
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
@@ -40,7 +40,7 @@ public class KeystoneProject implements Project {
     private String subtree;
     private String parents;
     private Boolean enabled = true;
-    private Map<String, String> extra = new HashMap<String, String>();
+    private Map<String, Object> extra = new HashMap<String, Object>();
 
     /**
      * @return the Project builder
@@ -149,17 +149,17 @@ public class KeystoneProject implements Project {
     /**
      * {@inheritDoc}
      */
-    public String getExtra(String key) {
+    public Object getExtra(String key) {
         return extra.get(key);
     }
 
     @JsonAnyGetter
-    public Map<String, String> getExtra() {
+    public Map<String, Object> getExtra() {
         return extra;
     }
 
     @JsonAnySetter
-    public void setExtra(String key, String value) {
+    public void setExtra(String key, Object value) {
         // is_domain is not necessary
         // if we don't ignore this, this will be set into extra field.
         if (Objects.equal(key, "is_domain")) {


### PR DESCRIPTION
In case some json attribute is not string typed in the payload, the mapping will fail.