### PR TITLE
Solving the problem "Get project by name get a NullPointerException". #1196

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/common/ListResult.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/ListResult.java
@@ -25,6 +25,11 @@ public abstract class ListResult<T> implements ModelEntity, ListType {
 
 	
     public T first() {
+		//add by chenyan 2018.6.6 -- start
+		if(null == value()){
+			return null;
+		}
+		//add by chenyan 2018.6.6 -- end
     	return value().isEmpty() ? null : value().get(0);   	
     }
 }


### PR DESCRIPTION
#1196
Solving the problem "Get project by name get a NullPointerException". 
Find project by name return a error，when the name of the project is not exists.

invoke the method：first()
get a NullPointerException.