### PR TITLE
Solves the issue #1198: "Identity service not working with OS4j".

### DIFF
--- a/core-test/src/main/resources/identity/v2/access.json
+++ b/core-test/src/main/resources/identity/v2/access.json
@@ -148,6 +148,25 @@
 						"adminURL": "http:\/\/127.0.0.1:8087\/v2.0",
 						"region": "RegionOne",
 						"internalURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"id": "9c66xrg3gruv2a3hj8aatd7smmas23fy",
+						"publicURL": "http:\/\/127.0.0.1:8087\/v2.0"
+					}, {
+						"adminURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"region": "RegionTwo",
+						"internalURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"id": "9c66xrgerruv2a3hj8batd7smmas23fy",
+						"publicURL": "http:\/\/127.0.0.1:8087\/v2.0"
+					}
+				],
+				"endpoints_links": [],
+				"type": "aodh",
+				"name": "alarming"
+			}, {
+				"endpoints": [
+					{
+						"adminURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"region": "RegionOne",
+						"internalURL": "http:\/\/127.0.0.1:8087\/v2.0",
 						"id": "9c66xrg3rruv2a3hj8tatd7smmas23fy",
 						"publicURL": "http:\/\/127.0.0.1:8087\/v2.0"
 					}, {

--- a/core-test/src/main/resources/identity/v3/authv3_project.json
+++ b/core-test/src/main/resources/identity/v3/authv3_project.json
@@ -485,6 +485,34 @@
         "endpoints": [
           {
             "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "123458912d3f49a09df51035681d59a8"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "123453dd1ae80457abc3728fa1e6f123"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "123451a45a7040849c03bc1358854321"
+          }
+        ],
+        "type": "aodh",
+        "id": "1236500210a24c38a1702e6825e12345",
+        "name": "alarming"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
             "url": "http://127.0.0.1:8082",
             "region": "RegionOne",
             "interface": "public",

--- a/core-test/src/main/resources/telemetry/alarm.json
+++ b/core-test/src/main/resources/telemetry/alarm.json
@@ -1,30 +1,29 @@
-[{
-		"alarm_id" : "03757eede9c540338e732d1a7fb07966",
-		"enabled": false,
-		"name": "name_post",
-		"state": "ok",
-		"type": "gnocchi_aggregation_by_metrics_threshold",
-		"severity": "critical",
-		"ok_actions": [
-			"http://something/ok"
+{
+	"alarm_id" : "03757eede9c540338e732d1a7fb07966",
+	"enabled": false,
+	"name": "name_post",
+	"state": "ok",
+	"type": "gnocchi_aggregation_by_metrics_threshold",
+	"severity": "critical",
+	"ok_actions": [
+		"http://something/ok"
+	],
+	"alarm_actions": [
+		"http://something/alarm"
+	],
+	"insufficient_data_actions": [
+		"http://something/no"
+	],
+	"repeat_actions": true,
+	"gnocchi_aggregation_by_metrics_threshold_rule": {
+		"metrics": [
+			"b3d9d8ab-05e8-439f-89ad-5e978dd2a5eb",
+			"009d4faf-c275-46f0-8f2d-670b15bac2b0"
 		],
-		"alarm_actions": [
-			"http://something/alarm"
-		],
-		"insufficient_data_actions": [
-			"http://something/no"
-		],
-		"repeat_actions": true,
-		"gnocchi_aggregation_by_metrics_threshold_rule": {
-			"metrics": [
-				"b3d9d8ab-05e8-439f-89ad-5e978dd2a5eb",
-				"009d4faf-c275-46f0-8f2d-670b15bac2b0"
-			],
-			"comparison_operator": "le",
-			"aggregation_method": "count",
-			"threshold": 50,
-			"evaluation_periods": 3,
-			"granularity": 180
-		}
+		"comparison_operator": "le",
+		"aggregation_method": "count",
+		"threshold": 50,
+		"evaluation_periods": 3,
+		"granularity": 180
 	}
-]
+}

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
@@ -15,3 +15,4 @@ public class BaseIdentityServices extends BaseOpenStackService {
                 super(ServiceType.IDENTITY, EnforceVersionToURL.instance("/v3"));
         }
 }
+

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
@@ -1,0 +1,17 @@
+package org.openstack4j.openstack.identity.v3.internal;
+
+import org.openstack4j.api.types.ServiceType;
+import org.openstack4j.openstack.common.functions.EnforceVersionToURL;
+import org.openstack4j.openstack.internal.BaseOpenStackService;
+
+/**
+ * Base Identity Operations Implementation is responsible for insuring the proper endpoint is used for all extending operation APIs
+ *
+ * @author Jyothi Saroja
+ */
+public class BaseIdentityServices extends BaseOpenStackService {
+
+        protected BaseIdentityServices() {
+                super(ServiceType.IDENTITY, EnforceVersionToURL.instance("/v3"));
+        }
+}

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/IdentityServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/IdentityServiceImpl.java
@@ -8,13 +8,12 @@ import org.openstack4j.api.Apis;
 import org.openstack4j.api.identity.v3.*;
 import org.openstack4j.model.common.Extension;
 import org.openstack4j.openstack.common.ExtensionValue.ExtensionList;
-import org.openstack4j.openstack.internal.BaseOpenStackService;
 
 /**
  * Identity V3 service implementation
  *
  */
-public class IdentityServiceImpl extends BaseOpenStackService implements IdentityService {
+public class IdentityServiceImpl extends BaseIdentityServices implements IdentityService {
 
     @Override
     public CredentialService credentials() {


### PR DESCRIPTION
The code below fixes the github issue #1198: "Identity service not working with OS4j".
Keystone version v3 is missed in the keystone endpoint URL due to which the Identity service APIs fail with the error message "Resource could not be found (404)". The code appends version "/v3" to the keystone endpoint URL which fixes the issue.
Added a new class "BaseIdentityServices" to enforce keystone version to endpoint URL.
