### PR TITLE
In case Content-length header is not returned use 0

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/functions/ParseObjectFunction.java
@@ -38,7 +38,7 @@ public class ParseObjectFunction implements Function<HttpResponse, SwiftObject> 
                   .name(location.getObjectName())
                   .containerName(location.getContainerName())
                   .mimeType(resp.header(CONTENT_TYPE))
-                  .sizeBytes(asLong(resp.header(CONTENT_LENGTH)))
+                  .sizeBytes(asLong(resp.header(CONTENT_LENGTH), 0L))
                   .eTag(resp.header(ETAG))
                   .metadata(MapWithoutMetaPrefixFunction.INSTANCE.apply(resp.headers()))
                   .lastModified(Parser.toRFC822DateParse(resp.header(LAST_MODIFIED)))


### PR DESCRIPTION
In some cases Swift is not returning Content-length header for HEAD object call. That causes NullPointerException for SwiftObject parsing.
As I found that is the case:
- When uploaded object is empty (zero size)
- If a number of DLO segments is larger than container listing limit: https://bugs.launchpad.net/swift/+bug/1680219

Python client is already handling this
``` # python-swiftclient/swiftclient/command_helpers.py
    content_length = prt_bytes(headers.get('content-length', 0),
                               options['human']).lstrip()
```

IMO this is awful way to handle this. And I'd be more happy if swift start returning content-length for all requests.