### PR TITLE
Implement listCachedImages() for Glance V2 Images

### DIFF
--- a/core/src/main/java/org/openstack4j/api/image/v2/ImageService.java
+++ b/core/src/main/java/org/openstack4j/api/image/v2/ImageService.java
@@ -3,6 +3,7 @@ package org.openstack4j.api.image.v2;
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.common.Payload;
+import org.openstack4j.model.image.v2.CachedImage;
 import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.image.v2.ImageUpdate;
 import org.openstack4j.model.image.v2.Member;
@@ -32,6 +33,13 @@ public interface ImageService extends RestService {
      * @return list of images fitered by filteringParams
      */
     List<? extends Image> list(Map<String, String> filteringParams);
+    
+    /**
+     * List images currently in the glance image cache.
+     *
+     * @return list of cached images or empty list if the cache is empty or null if the cache is not enabled.
+     */
+    List<? extends CachedImage> listCachedImages() ;
 
     /**
      * Show details for an image by imageid.

--- a/core/src/main/java/org/openstack4j/model/image/v2/CachedImage.java
+++ b/core/src/main/java/org/openstack4j/model/image/v2/CachedImage.java
@@ -1,0 +1,41 @@
+package org.openstack4j.model.image.v2;
+
+import org.openstack4j.model.ModelEntity;
+import java.util.Date;
+
+/**
+ * @author zdagjyo on 13/11/2018.
+ * @see https://docs.openstack.org/developer/glance/cache.html
+ */
+public interface CachedImage extends ModelEntity {
+
+    /**
+     *
+     * @return the image id of the cached image
+     */
+    String getImageId();
+
+    /**
+     *
+     * @return date when this image was last accessed in the cache
+     */
+    Date getLastAccessed();
+
+    /**
+     *
+     * @return date when the image was last modified in the cache
+     */
+    Date getLastModified();
+
+    /**
+     *
+     * @return nr of cache hits
+     */
+    Integer getHits();
+
+    /**
+     *
+     * @return the image size
+     */
+    Long getSize();
+}

--- a/core/src/main/java/org/openstack4j/openstack/image/v2/domain/CachedGlanceImage.java
+++ b/core/src/main/java/org/openstack4j/openstack/image/v2/domain/CachedGlanceImage.java
@@ -1,0 +1,82 @@
+package org.openstack4j.openstack.image.v2.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Objects;
+import org.openstack4j.model.image.v2.CachedImage;
+import org.openstack4j.openstack.common.CustomEpochToDateDeserializer;
+import org.openstack4j.openstack.common.ListResult;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author zdagjyo on 13/11/2018.
+ */
+public class CachedGlanceImage implements CachedImage {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("image_id")
+    private String imageId;
+
+    private Integer hits;
+
+    @JsonProperty("last_accessed")
+    @JsonDeserialize(using = CustomEpochToDateDeserializer.class)
+    private Date lastAccessed;
+
+    @JsonDeserialize(using = CustomEpochToDateDeserializer.class)
+    @JsonProperty("last_modified")
+    private Date lastModified;
+
+    private Long size;
+
+    @Override
+    public String getImageId() {
+        return imageId;
+    }
+
+    @Override
+    public Date getLastAccessed() {
+        return lastAccessed;
+    }
+
+    @Override
+    public Date getLastModified() {
+        return lastModified;
+    }
+
+    @Override
+    public Integer getHits() {
+        return hits;
+    }
+
+    @Override
+    public Long getSize() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).omitNullValues()
+                .add("id", imageId).add("size", size).add("hits", hits).add("lastAccessed", lastAccessed)
+                .add("lastModified", lastModified).addValue("\n")
+                .toString();
+    }
+
+    public static class CachedImages extends ListResult<CachedGlanceImage> {
+
+        private static final long serialVersionUID = 1L;
+        @JsonProperty("cached_images")
+        private List<CachedGlanceImage> cachedImages;
+
+        @Override
+        protected List<CachedGlanceImage> value() {
+            return cachedImages;
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/image/v2/internal/ImageServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/image/v2/internal/ImageServiceImpl.java
@@ -5,14 +5,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonpatch.diff.JsonDiff;
 import org.openstack4j.api.Apis;
+import org.openstack4j.api.exceptions.ResponseException;
 import org.openstack4j.api.image.v2.ImageService;
 import org.openstack4j.api.image.v2.TaskService;
+import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.HttpResponse;
+import org.openstack4j.core.transport.propagation.PropagateOnStatus;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.common.Payload;
+import org.openstack4j.model.image.v2.CachedImage;
 import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.image.v2.ImageUpdate;
 import org.openstack4j.model.image.v2.Member;
+import org.openstack4j.openstack.image.v2.domain.CachedGlanceImage.CachedImages;
 import org.openstack4j.openstack.image.v2.domain.GlanceImage;
 import org.openstack4j.openstack.image.v2.domain.GlanceImageUpdate;
 import org.openstack4j.openstack.image.v2.domain.GlanceMember;
@@ -51,6 +56,20 @@ public class ImageServiceImpl extends BaseImageServices implements ImageService 
     @Override
     public List<? extends Image> list(Map<String, String> filteringParams) {
         return get(GlanceImage.Images.class, uri("/images")).params(filteringParams).execute().getList();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends CachedImage> listCachedImages() {
+    	try {
+            return get(CachedImages.class, uri("/cached_images"))
+                    .execute(ExecutionOptions.<CachedImages>create(PropagateOnStatus.on(404))).getList();
+        }
+        catch (ResponseException e) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request implements the listCachedImages() API to list the cached images for Glance v2 images.
This API is available in glance v1 but is missing in v2 version. Hence implemented the same for V2.