### PR TITLE
Add compute API 2.15  Microversion for server groups

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/BaseMicroVersionedComputeServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/BaseMicroVersionedComputeServices.java
@@ -1,0 +1,31 @@
+package org.openstack4j.openstack.compute.internal;
+
+import org.openstack4j.api.types.ServiceType;
+import org.openstack4j.openstack.internal.MicroVersion;
+import org.openstack4j.openstack.internal.MicroVersionedOpenStackService;
+
+class BaseMicroVersionedComputeServices extends MicroVersionedOpenStackService {
+
+    static MicroVersion MICRO_VERSION_2_15 = new MicroVersion(2, 15);
+
+    BaseMicroVersionedComputeServices(MicroVersion microVersion) {
+        super(ServiceType.COMPUTE, new ComputeMicroVersion(microVersion));
+    }
+
+    @Override
+    protected String getApiVersionHeader() {
+        return "OpenStack-API-Version";
+    }
+
+    private static class ComputeMicroVersion extends MicroVersion {
+
+        ComputeMicroVersion(MicroVersion microVersion) {
+            super(microVersion.toString());
+        }
+
+        @Override
+        public String toString() {
+            return "compute " + super.toString();
+        }
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerGroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerGroupServiceImpl.java
@@ -10,7 +10,11 @@ import org.openstack4j.model.compute.ServerGroup;
 import org.openstack4j.openstack.compute.domain.NovaServerGroup;
 import org.openstack4j.openstack.compute.domain.NovaServerGroup.ServerGroups;
 
-public class ServerGroupServiceImpl extends BaseComputeServices implements ServerGroupService {
+public class ServerGroupServiceImpl extends BaseMicroVersionedComputeServices implements ServerGroupService {
+
+	public ServerGroupServiceImpl() {
+		super(MICRO_VERSION_2_15);
+	}
 
 	@Override
 	public List<? extends ServerGroup> list() {


### PR DESCRIPTION
Adds the `OpenStack-API-Version: compute 2.15` header to the `ServerGroupServiceImpl` to support newer group policies of `soft-affinity` and `soft-anti-affinity`.

See this for more details:
https://bugzilla.redhat.com/show_bug.cgi?id=1598484 