### PR TITLE
maxoversubscription_ratio is float type

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderBackendStoragePool.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/domain/CinderBackendStoragePool.java
@@ -61,7 +61,7 @@ public class CinderBackendStoragePool implements VolumeBackendPool {
         @JsonProperty("QoS_support")
         private Boolean qosSupport;
         @JsonProperty("max_over_subscription_ratio")
-        private Long maxoversubscription_ratio;
+        private Float maxoversubscription_ratio;
         @JsonProperty("vendor_name")
         private String vendorname;
         private String pools;
@@ -97,7 +97,9 @@ public class CinderBackendStoragePool implements VolumeBackendPool {
         @Override
         public Boolean getThickprovisioningsupport() { return thickprovisioningsupport; }
         @Override
-        public Long getMaxoversubscription_ratio() { return maxoversubscription_ratio; }
+        public Float getMaxoversubscription_ratio() { 
+            return maxoversubscription_ratio; 
+        }
         @Override
         public String getvendorname() { return vendorname; }
         @Override


### PR DESCRIPTION
maxoversubscription_ratio is float type
cinder --debug get-pools --detail
+-----------------------------+----------------------------------------------------------------------------------------------+
| Property                    | Value                                                                                        |
+-----------------------------+----------------------------------------------------------------------------------------------+
| allocated_capacity_gb       | 113                                                                                          |
| backend_state               | up                                                                                           |
| driver_version              | 1.2.0                                                                                        |
| filter_function             | None                                                                                         |
| free_capacity_gb            | 3007.03                                                                                      |
| goodness_function           | None                                                                                         |
| location_info               | ceph:/etc/ceph/ceph.conf:53cca19d-7ebf-40d4-9d21-a827c83ed7b0:cinder_ha_test:ha_volumes_test |
| max_over_subscription_ratio | 20.0                                                                                         |
| multiattach                 | False                                                                                        |
| name                        | lenovo2@ceph#ceph                                                                            |
| provisioned_capacity_gb     | 115.0                                                                                        |
| replication_enabled         | False                                                                                        |
| reserved_percentage         | 0                                                                                            |
| storage_protocol            | ceph                                                                                         |
| thin_provisioning_support   | True                                                                                         |
| timestamp                   | 2020-03-16T06:59:50.194205                                                                   |
| total_capacity_gb           | 3007.03                                                                                      |
| vendor_name                 | Open Source                                                                                  |
| volume_backend_name         | ceph                                                                                         |
+-----------------------------+----------------------------------------------------------------------------------------------+
