### PR TITLE
Add batch delete function of security group rule.

### DIFF
--- a/core/src/main/java/org/openstack4j/api/networking/SecurityGroupRuleService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/SecurityGroupRuleService.java
@@ -35,6 +35,13 @@ public interface SecurityGroupRuleService extends RestService {
    * @param id the id
    */
   void delete(String id);
+
+  /**
+   * Batch delete security group rule by ids.
+   *
+   * @param ruleIds The security group rule ids.
+   */
+  void batchDelete(List<String> ruleIds);
   
   /**
    * Creates a security group rule.

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupRuleServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupRuleServiceImpl.java
@@ -39,6 +39,18 @@ public class SecurityGroupRuleServiceImpl extends BaseNetworkingServices impleme
      * {@inheritDoc}
      */
     @Override
+    public void batchDelete(List<String> ruleIds) {
+        if (ruleIds != null && ruleIds.size() > 0){
+            for (String ruleId: ruleIds) {
+                delete(Void.class, uri("/security-group-rules/%s", ruleId)).execute();
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public SecurityGroupRule create(SecurityGroupRule rule) {
         checkNotNull(rule);
         return post(NeutronSecurityGroupRule.class, uri("/security-group-rules")).entity(rule).execute();


### PR DESCRIPTION
I'm using security groups to implement the whitelist feature, which requires delete security group rules in batches but is not implemented in openstack 4J, so submit the request.If there are any deficiencies, please correct them, thanks.
In addition, I found that there were no unit tests related to the safety group rules, which I would add if have free time.