### PR TITLE
Avoid MismatchedInputException when reading KeystoneProject from JSON

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneProject.java
@@ -166,13 +166,16 @@ public class KeystoneProject implements Project {
     }
 
     @JsonAnySetter
-    public void setExtra(String key, String value) {
+    public void setExtra(String key, Object value) {
         // is_domain is not necessary
         // if we don't ignore this, this will be set into extra field.
         if (Objects.equal(key, "is_domain")) {
             return;
         }
-        extra.put(key, value);
+
+        if (value instanceof String) {
+            extra.put(key, (String) value);
+        }
     }
 
     /**
@@ -339,7 +342,7 @@ public class KeystoneProject implements Project {
 
 
         /**
-         * @see KeystoneProject#setExtra(String, String)
+         * @see KeystoneProject#setExtra(String, Object)
          */
         @Override
         public ProjectBuilder setExtra(String key, String value) {


### PR DESCRIPTION
Avoid MismatchedInputException when reading KeystoneProject from JSON

Fixes  #1299